### PR TITLE
Add jose list command

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,6 +13,7 @@ libjose_la_SOURCES = \
     lib/misc.c lib/misc.h \
     lib/buf.c \
     lib/b64.c \
+    lib/hooks.c \
     lib/jwk.c \
     lib/jws.c \
     lib/jwe.c \
@@ -59,6 +60,7 @@ cmd_jose_SOURCES = \
     cmd/ver.c \
     cmd/enc.c \
     cmd/dec.c \
+    cmd/sup.c \
     cmd/jose.c \
     cmd/jose.h
 

--- a/cmd/jose.c
+++ b/cmd/jose.c
@@ -223,6 +223,7 @@ main(int argc, char *argv[])
         { "ver", jcmd_ver },
         { "enc", jcmd_enc },
         { "dec", jcmd_dec },
+        { "sup", jcmd_sup },
         {}
     };
 
@@ -255,6 +256,7 @@ main(int argc, char *argv[])
 "\n  jose " VER_USE
 "\n  jose " ENC_USE
 "\n  jose " DEC_USE
+"\n  jose " SUP_USE
 "\n");
     return EXIT_FAILURE;
 }

--- a/cmd/jose.h
+++ b/cmd/jose.h
@@ -42,6 +42,9 @@
 #define DEC_USE \
     "dec -i JWE [-n] [-k JWK(Set) ...] [-o PLD]"
 
+#define SUP_USE \
+    "sup"
+
 void *
 jcmd_load_data(const char *file, size_t *len);
 
@@ -82,3 +85,6 @@ jcmd_enc(int argc, char *argv[]);
 
 int
 jcmd_dec(int argc, char *argv[]);
+
+int
+jcmd_sup(int argc, char *argv[]);

--- a/cmd/sup.c
+++ b/cmd/sup.c
@@ -1,0 +1,110 @@
+/* vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80: */
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cmd/jose.h>
+#include <jose/hooks.h>
+
+static const struct option opts[] = {
+    { "help",      no_argument,       .val = 'h' },
+    {}
+};
+
+int
+jcmd_sup(int argc, char *argv[])
+{
+    jose_jwk_type_t *type;
+    jose_jwk_op_t *op;
+    jose_jwk_generator_t *generator;
+    jose_jwk_hasher_t *hasher;
+    jose_jws_signer_t *signer;
+    jose_jwe_crypter_t *crypter;
+    jose_jwe_wrapper_t *wrapper;
+    jose_jwe_zipper_t *zipper;
+    char **p;
+
+    for (int c; (c = getopt_long(argc, argv, "h", opts, NULL)) >= 0; ) {
+        switch (c) {
+        case 'h': goto usage;
+        default:
+            fprintf(stderr, "Invalid option: %c!\n", c);
+            goto usage;
+        }
+    }
+
+#define FMT(t) ((t)->next ?  " %s," : " %s")
+#define FMTOP(t) ((t)->next ? " [%s]%s/%s," : " [%s]%s/%s")
+#define FMTP(t, p) (((t)->next || *((p)+1)) ? " %s," : " %s")
+
+    fprintf(stdout, "jwk_type:");
+    for (type = jose_jwk_types(); type; type = type->next)
+        fprintf(stdout, FMT(type), type->kty);
+
+    fprintf(stdout, "\n");
+
+    fprintf(stdout, "jwk_op:");
+    for (op = jose_jwk_ops(); op; op = op->next)
+        fprintf(stdout, FMTOP(op), op->use, op->pub, op->prv);
+
+    fprintf(stdout, "\n");
+
+    fprintf(stdout, "jwk_generator:");
+    for (generator = jose_jwk_generators(); generator; generator = generator->next)
+        fprintf(stdout, FMT(generator), generator->kty);
+
+    fprintf(stdout, "\n");
+
+    fprintf(stdout, "jwk_hasher:");
+    for (hasher = jose_jwk_hashers(); hasher; hasher = hasher->next)
+        fprintf(stdout, FMT(hasher), hasher->name);
+
+    fprintf(stdout, "\n");
+
+    fprintf(stdout, "jws_signer:");
+    for (signer = jose_jws_signers(); signer; signer = signer->next) {
+        for (p = (char **)signer->algs; p && *p; p++)
+            fprintf(stdout, FMTP(signer, p), *p);
+    }
+    fprintf(stdout, "\n");
+
+    fprintf(stdout, "jwe_crypter:");
+    for (crypter = jose_jwe_crypters(); crypter; crypter = crypter->next) {
+        for (p = (char **)crypter->encs; p && *p; p++)
+            fprintf(stdout, FMTP(crypter, p), *p);
+    }
+    fprintf(stdout, "\n");
+
+    fprintf(stdout, "jwe_wrapper:");
+    for (wrapper = jose_jwe_wrappers(); wrapper; wrapper = wrapper->next) {
+        for (p = (char **)wrapper->algs; p && *p; p++)
+            fprintf(stdout, FMTP(wrapper, p), *p);
+    }
+    fprintf(stdout, "\n");
+
+    fprintf(stdout, "jwe_zipper:");
+    for (zipper = jose_jwe_zippers(); zipper; zipper = zipper->next)
+        fprintf(stdout, FMT(zipper), zipper->zip);
+    fprintf(stdout, "\n");
+
+    return EXIT_SUCCESS;
+usage:
+    fprintf(stderr,
+"jose " SUP_USE
+"\n"
+"\nList all supported and loaded algorithms."
+"\n");
+    return EXIT_FAILURE;
+}

--- a/jose/hooks.h
+++ b/jose/hooks.h
@@ -113,29 +113,59 @@ typedef struct jose_jwe_zipper {
 void
 jose_jwk_register_type(jose_jwk_type_t *type);
 
+jose_jwk_type_t *
+jose_jwk_types(void);
+
 void
 jose_jwk_register_op(jose_jwk_op_t *op);
+
+jose_jwk_op_t *
+jose_jwk_ops(void);
 
 void
 jose_jwk_register_resolver(jose_jwk_resolver_t *resolver);
 
+jose_jwk_resolver_t *
+jose_jwk_resolvers(void);
+
 void
 jose_jwk_register_generator(jose_jwk_generator_t *generator);
+
+jose_jwk_generator_t *
+jose_jwk_generators(void);
 
 void
 jose_jwk_register_hasher(jose_jwk_hasher_t *hasher);
 
+jose_jwk_hasher_t *
+jose_jwk_hashers(void);
+
 void
 jose_jwk_register_exchanger(jose_jwk_exchanger_t *exchanger);
+
+jose_jwk_exchanger_t *
+jose_jwk_exchangers(void);
 
 void
 jose_jws_register_signer(jose_jws_signer_t *signer);
 
+jose_jws_signer_t *
+jose_jws_signers(void);
+
 void
 jose_jwe_register_crypter(jose_jwe_crypter_t *crypter);
+
+jose_jwe_crypter_t *
+jose_jwe_crypters(void);
 
 void
 jose_jwe_register_wrapper(jose_jwe_wrapper_t *wrapper);
 
+jose_jwe_wrapper_t *
+jose_jwe_wrappers(void);
+
 void
 jose_jwe_register_zipper(jose_jwe_zipper_t *zipper);
+
+jose_jwe_zipper_t *
+jose_jwe_zippers(void);

--- a/lib/hooks.c
+++ b/lib/hooks.c
@@ -1,0 +1,159 @@
+/* vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80: */
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <jose/hooks.h>
+
+static jose_jwk_type_t *types;
+static jose_jwk_op_t *ops;
+static jose_jwk_resolver_t *resolvers;
+static jose_jwk_generator_t *generators;
+static jose_jwk_hasher_t *hashers;
+static jose_jwk_exchanger_t *exchangers;
+static jose_jws_signer_t *signers;
+static jose_jwe_crypter_t *crypters;
+static jose_jwe_wrapper_t *wrappers;
+static jose_jwe_zipper_t *zippers;
+
+void
+jose_jwk_register_type(jose_jwk_type_t *type)
+{
+    type->next = types;
+    types = type;
+}
+
+jose_jwk_type_t *
+jose_jwk_types(void)
+{
+    return types;
+}
+
+void
+jose_jwk_register_op(jose_jwk_op_t *op)
+{
+    op->next = ops;
+    ops = op;
+}
+
+jose_jwk_op_t *
+jose_jwk_ops(void)
+{
+    return ops;
+}
+
+void
+jose_jwk_register_resolver(jose_jwk_resolver_t *resolver)
+{
+    resolver->next = resolvers;
+    resolvers = resolver;
+}
+
+jose_jwk_resolver_t *
+jose_jwk_resolvers(void)
+{
+    return resolvers;
+}
+
+void
+jose_jwk_register_generator(jose_jwk_generator_t *generator)
+{
+    generator->next = generators;
+    generators = generator;
+}
+
+jose_jwk_generator_t *
+jose_jwk_generators(void)
+{
+    return generators;
+}
+
+void
+jose_jwk_register_hasher(jose_jwk_hasher_t *hasher)
+{
+    hasher->next = hashers;
+    hashers = hasher;
+}
+
+jose_jwk_hasher_t *
+jose_jwk_hashers(void)
+{
+    return hashers;
+}
+
+void
+jose_jwk_register_exchanger(jose_jwk_exchanger_t *exchanger)
+{
+    exchanger->next = exchangers;
+    exchangers = exchanger;
+}
+
+jose_jwk_exchanger_t *
+jose_jwk_exchangers(void)
+{
+    return exchangers;
+}
+
+void
+jose_jws_register_signer(jose_jws_signer_t *signer)
+{
+    signer->next = signers;
+    signers = signer;
+}
+
+jose_jws_signer_t *
+jose_jws_signers(void)
+{
+    return signers;
+}
+
+void
+jose_jwe_register_crypter(jose_jwe_crypter_t *crypter)
+{
+    crypter->next = crypters;
+    crypters = crypter;
+}
+
+jose_jwe_crypter_t *
+jose_jwe_crypters(void)
+{
+    return crypters;
+}
+
+void
+jose_jwe_register_wrapper(jose_jwe_wrapper_t *wrapper)
+{
+    wrapper->next = wrappers;
+    wrappers = wrapper;
+}
+
+jose_jwe_wrapper_t *
+jose_jwe_wrappers(void)
+{
+    return wrappers;
+}
+
+void
+jose_jwe_register_zipper(jose_jwe_zipper_t *zipper)
+{
+    zipper->next = zippers;
+    zippers = zipper;
+}
+
+jose_jwe_zipper_t *
+jose_jwe_zippers(void)
+{
+    return zippers;
+}

--- a/lib/jws.c
+++ b/lib/jws.c
@@ -25,19 +25,10 @@
 
 #include <string.h>
 
-static jose_jws_signer_t *signers;
-
-void
-jose_jws_register_signer(jose_jws_signer_t *signer)
-{
-    signer->next = signers;
-    signers = signer;
-}
-
 static const jose_jws_signer_t *
 find(const char *alg)
 {
-    for (const jose_jws_signer_t *s = signers; s; s = s->next) {
+    for (const jose_jws_signer_t *s = jose_jws_signers(); s; s = s->next) {
         for (size_t i = 0; s->algs[i]; i++) {
             if (strcmp(alg, s->algs[i]) == 0)
                 return s;
@@ -84,7 +75,7 @@ jose_jws_sign(json_t *jws, const json_t *jwk, const json_t *sig)
     if (json_unpack(p, "{s:s}", "alg", &alg) == -1 &&
         json_unpack(s, "{s:{s:s}}", "header", "alg", &alg) == -1) {
         alg = kalg;
-        for (signer = signers; signer && !alg; signer = signer->next)
+        for (signer = jose_jws_signers(); signer && !alg; signer = signer->next)
             alg = signer->suggest(jwk);
 
         if (!set_protected_new(s, "alg", json_string(alg)))

--- a/tests/jose
+++ b/tests/jose
@@ -135,3 +135,9 @@ for alg in $AWRAP $SWRAP; do
         cmd/jose dec -i $tmpdir/$enc.$alg.jwe -k $tmpdir/$alg.jwk
     done
 done
+
+##
+### Test supported algorithms
+##
+cmd/jose sup
+


### PR DESCRIPTION
The new cmd/jose list commands lists all registered types, ops,
generators etc.. It's main purpose is introspection and debugging
problems like #13.

```
$ cmd/jose list
jwk_type: EC, RSA, oct
jwk_op: [enc]wrapKey/unwrapKey, [enc]encrypt/decrypt, [sig]verify/sign
jwk_generator: EC, RSA, oct
jwk_hasher: sha512, sha384, sha256, sha224, sha1
jws_signer: RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384, ES512, HS256, HS384, HS512
jwe_crypter: A128GCM, A192GCM, A256GCM, A128CBC-HS256, A192CBC-HS384, A256CBC-HS512
jwe_wrapper: A128KW, A192KW, A256KW, PBES2-HS256+A128KW, PBES2-HS384+A192KW, PBES2-HS512+A256KW, RSA1_5, RSA-OAEP, RSA-OAEP-256,
A128GCMKW, A192GCMKW, A256GCMKW, ECDH-ES, ECDH-ES+A128KW, ECDH-ES+A192KW, ECDH-ES+A256KW, dir
jwe_zipper: DEF
```

Signed-off-by: Christian Heimes <christian@python.org>