### PR TITLE
dlopen() additional plugin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ pkgconfigdir = $(libdir)/pkgconfig
 inc_HEADERS = jose/buf.h jose/b64.h jose/jwk.h jose/jws.h jose/jwe.h jose/jose.h jose/hooks.h
 pkgconfig_DATA = jose.pc
 lib_LTLIBRARIES = libjose.la
-libjose_la_LIBADD = @jansson_LIBS@
+libjose_la_LIBADD = @jansson_LIBS@ -ldl
 libjose_la_LDFLAGS = -export-symbols-regex '^jose_'
 libjose_la_SOURCES = \
     lib/misc.c lib/misc.h \
@@ -49,8 +49,8 @@ libjose_openssl_la_SOURCES = \
     lib/openssl/sha.c
 
 bin_PROGRAMS = cmd/jose
-cmd_jose_CFLAGS = $(AM_CFLAGS) @libcrypto_CFLAGS@
-cmd_jose_LDADD = libjose-openssl.la
+cmd_jose_CFLAGS = $(AM_CFLAGS)
+cmd_jose_LDADD =
 cmd_jose_SOURCES = \
     cmd/gen.c \
     cmd/pub.c \

--- a/cmd/jose.c
+++ b/cmd/jose.c
@@ -17,8 +17,6 @@
 
 #include <cmd/jose.h>
 
-#include <openssl/rand.h>
-
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <string.h>
@@ -227,9 +225,12 @@ main(int argc, char *argv[])
         {}
     };
 
-    const char *cmd = NULL;
+    if (! jose_load_all_plugins()) {
+        fprintf(stderr, "jose plugin error\n");
+        return EXIT_FAILURE;
+    }
 
-    RAND_poll();
+    const char *cmd = NULL;
 
     if (argc >= 2) {
         char argv0[strlen(argv[0]) + strlen(argv[1]) + 2];

--- a/jose/hooks.h
+++ b/jose/hooks.h
@@ -110,6 +110,21 @@ typedef struct jose_jwe_zipper {
     (*inflate)(const uint8_t val[], size_t len);
 } jose_jwe_zipper_t;
 
+enum jose_plugin_state {
+    JOSE_PLUGIN_NOT_FOUND = -2,
+    JOSE_PLUGIN_FAILED = -1,
+    JOSE_PLUGIN_NOT_LOADED,
+    JOSE_PLUGIN_LOADED,
+};
+
+typedef struct jose_plugin {
+    const char *name;
+    const char *lib;
+    bool load_all;
+    enum jose_plugin_state state;
+    void *handle;
+} jose_plugin_t;
+
 void
 jose_jwk_register_type(jose_jwk_type_t *type);
 
@@ -169,3 +184,12 @@ jose_jwe_register_zipper(jose_jwe_zipper_t *zipper);
 
 jose_jwe_zipper_t *
 jose_jwe_zippers(void);
+
+bool
+jose_load_all_plugins(void);
+
+enum jose_plugin_state
+jose_load_plugin(const char *name);
+
+jose_plugin_t*
+jose_get_plugins(void);

--- a/jose/jose.h
+++ b/jose/jose.h
@@ -21,6 +21,7 @@
 #include "jwk.h"
 #include "jws.h"
 #include "jwe.h"
+#include "hooks.h"
 
 /**
  * Converts a JWS or JWE from compact format into JSON format.

--- a/lib/openssl/jwk.c
+++ b/lib/openssl/jwk.c
@@ -374,3 +374,9 @@ jose_openssl_jwk_to_EC_KEY(const json_t *jwk)
     return EC_KEY_up_ref(key) <= 0 ? NULL : key;
 }
 
+static void __attribute__((constructor))
+constructor(void)
+{
+    /* init CPRNG */
+    RAND_poll();
+}


### PR DESCRIPTION
On some systems the jose does not automatically load plugin shared
libraries. A constructor in libjose now attempts to dlopen() the
libraries. Failures are ignored.

Closes: #13
Signed-off-by: Christian Heimes <christian@python.org>