### PR TITLE
Add hook registration APIs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -75,6 +75,7 @@ dist_check_SCRIPTS = \
 endif
 
 if USE_ZLIB
+inc_HEADERS += jose/zlib.h
 pkgconfig_DATA += jose-zlib.pc
 lib_LTLIBRARIES += libjose-zlib.la
 libjose_zlib_la_CFLAGS = $(AM_CFLAGS) @zlib_CFLAGS@

--- a/cmd/jose.c
+++ b/cmd/jose.c
@@ -16,8 +16,8 @@
  */
 
 #include <cmd/jose.h>
-
-#include <openssl/rand.h>
+#include <jose/openssl.h>
+#include <jose/zlib.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -229,7 +229,8 @@ main(int argc, char *argv[])
 
     const char *cmd = NULL;
 
-    RAND_poll();
+    jose_openssl_hooks_register();
+    jose_zlib_hooks_register();
 
     if (argc >= 2) {
         char argv0[strlen(argv[0]) + strlen(argv[1]) + 2];

--- a/jose/zlib.h
+++ b/jose/zlib.h
@@ -17,31 +17,5 @@
 
 #pragma once
 
-#include <jansson.h>
-#include <openssl/evp.h>
-#include <openssl/ec.h>
-
 void
-jose_openssl_hooks_register(void);
-
-json_t *
-jose_openssl_jwk_from_EVP_PKEY(EVP_PKEY *key);
-
-json_t *
-jose_openssl_jwk_from_RSA(const RSA *key);
-
-json_t *
-jose_openssl_jwk_from_EC_KEY(const EC_KEY *key);
-
-json_t *
-jose_openssl_jwk_from_EC_POINT(const EC_GROUP *grp, const EC_POINT *pub,
-                               const BIGNUM *prv);
-
-EVP_PKEY *
-jose_openssl_jwk_to_EVP_PKEY(const json_t *jwk);
-
-RSA *
-jose_openssl_jwk_to_RSA(const json_t *jwk);
-
-EC_KEY *
-jose_openssl_jwk_to_EC_KEY(const json_t *jwk);
+jose_zlib_hooks_register(void);

--- a/lib/openssl/misc.c
+++ b/lib/openssl/misc.c
@@ -19,6 +19,8 @@
 #include <jose/b64.h>
 #include <string.h>
 
+#include <openssl/rand.h>
+
 size_t
 str2enum(const char *str, ...)
 {
@@ -94,4 +96,12 @@ bn_encode_json(const BIGNUM *bn, size_t len)
     }
 
     return NULL;
+}
+
+void
+jose_openssl_hooks_register(void)
+{
+    /* All actual hooks are loaded through constructors. */
+    OpenSSL_add_all_algorithms();
+    RAND_poll();
 }

--- a/lib/zlib/deflate.c
+++ b/lib/zlib/deflate.c
@@ -101,8 +101,8 @@ comp_inflate(const uint8_t *buf, size_t len)
     return jose_buf_incref(out);
 }
 
-static void __attribute__((constructor))
-constructor(void)
+void
+jose_zlib_hooks_register(void)
 {
     static jose_jwe_zipper_t zipper = {
         .zip = "DEF",


### PR DESCRIPTION
Using constructors alone to register hooks means that in some configurations, linking will never be performed. The end application needs to call at least one function in the library to ensure linking. Therefore, each implementation library (openssl, zlib, etc.) needs to define a hook registration function.

Using a consistant naming scheme and arguments ensures that these modules can be loaded via dlopen() easily as well.