### PR TITLE
Add API to load plugins

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,7 +51,7 @@ libjose_openssl_la_SOURCES = \
     lib/openssl/lock.c
 
 bin_PROGRAMS = cmd/jose
-cmd_jose_CFLAGS = $(AM_CFLAGS) @libcrypto_CFLAGS@
+cmd_jose_CFLAGS = $(AM_CFLAGS) @libcrypto_CFLAGS@ @jansson_LIBS@
 cmd_jose_LDADD = libjose.la libjose-openssl.la @jansson_LIBS@
 cmd_jose_SOURCES = \
     cmd/gen.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,7 @@ pkgconfigdir = $(libdir)/pkgconfig
 inc_HEADERS = jose/buf.h jose/b64.h jose/jwk.h jose/jws.h jose/jwe.h jose/jose.h jose/hooks.h
 pkgconfig_DATA = jose.pc
 lib_LTLIBRARIES = libjose.la
-libjose_la_LIBADD = @jansson_LIBS@
+libjose_la_LIBADD = @jansson_LIBS@ -ldl
 libjose_la_LDFLAGS = -export-symbols-regex '^jose_'
 libjose_la_SOURCES = \
     lib/misc.c lib/misc.h \
@@ -51,7 +51,7 @@ libjose_openssl_la_SOURCES = \
     lib/openssl/lock.c
 
 bin_PROGRAMS = cmd/jose
-cmd_jose_CFLAGS = $(AM_CFLAGS) @libcrypto_CFLAGS@ @jansson_LIBS@
+cmd_jose_CFLAGS = $(AM_CFLAGS) @libcrypto_CFLAGS@ @jansson_CFLAGS@
 cmd_jose_LDADD = libjose.la libjose-openssl.la @jansson_LIBS@
 cmd_jose_SOURCES = \
     cmd/gen.c \

--- a/cmd/jose.c
+++ b/cmd/jose.c
@@ -227,6 +227,11 @@ main(int argc, char *argv[])
 
     const char *cmd = NULL;
 
+    if (!jose_load_all_plugins()) {
+        fprintf(stderr, "jose plugin error\n");
+        return EXIT_FAILURE;
+    }
+
     if (argc >= 2) {
         char argv0[strlen(argv[0]) + strlen(argv[1]) + 2];
         strcpy(argv0, argv[0]);

--- a/jose/hooks.h
+++ b/jose/hooks.h
@@ -110,6 +110,19 @@ typedef struct jose_jwe_zipper {
     (*inflate)(const uint8_t val[], size_t len);
 } jose_jwe_zipper_t;
 
+enum jose_plugin_state {
+    JOSE_PLUGIN_NOT_FOUND = -1,
+    JOSE_PLUGIN_FAILED,
+    JOSE_PLUGIN_LOADED,
+};
+
+typedef struct jose_plugin {
+    struct jose_plugin *next;
+    const char *name;
+    enum jose_plugin_state state;
+    void *handle;
+} jose_plugin_t;
+
 void
 jose_jwk_register_type(jose_jwk_type_t *type);
 
@@ -169,3 +182,12 @@ jose_jwe_register_zipper(jose_jwe_zipper_t *zipper);
 
 jose_jwe_zipper_t *
 jose_jwe_zippers(void);
+
+bool
+jose_load_all_plugins(void);
+
+enum jose_plugin_state
+jose_load_plugin(const char *name);
+
+jose_plugin_t*
+jose_plugins(void);

--- a/jose/jose.h
+++ b/jose/jose.h
@@ -21,6 +21,7 @@
 #include "jwk.h"
 #include "jws.h"
 #include "jwe.h"
+#include "hooks.h"
 
 /**
  * Converts a JWS or JWE from compact format into JSON format.


### PR DESCRIPTION
On some systems the jose does not automatically load plugin shared
libraries. The function jose_load_all_plugins() loads all plugins
that are marked as 'load all'. jose_load_plugin(name) loads a
shared library plugin by name. jose_plugins() returns a pointer
to a struct with all registered plugins (loaded or failed).

Plugins are named "libjose-NAME.so".

Closes: #13
Signed-off-by: Christian Heimes <christian@python.org>