### PR TITLE
Fix NULL pointer dereference in jcmd_opt_set_jwkt()

### DIFF
--- a/cmd/jose.c
+++ b/cmd/jose.c
@@ -338,6 +338,9 @@ jcmd_opt_set_jwkt(const jcmd_cfg_t *cfg, void *vopt, const char *arg)
         }
     }
 
+    if (!tmp)
+        return false;
+
     switch (json_typeof(tmp)) {
     case JSON_OBJECT:
     case JSON_STRING:


### PR DESCRIPTION
The jcmd_opt_set_jwkt() function calls json_loads() to decode the JSON
passed using the -i option. This function returns NULL on error and in
this case is attempted to first get the JSON from either the standard
input or a file.

But it's never checked again if one of those succeeded, so an invalid
JSON passed to jose jwk {gen,exc} leads to a NULL pointer dereference:

$ jose jwk gen -i '{"kty":"oct",,"bytes":32}' -o oct.jwk
Segmentation fault (core dumped)

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>