### PR TITLE
Add jose pbkdf2 

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -24,4 +24,5 @@ jose_SOURCES = \
     jwe/dec.c \
     jwe/enc.c \
     alg.c \
-    fmt.c
+    fmt.c \
+    pbkdf2.c

--- a/cmd/pbkdf2.c
+++ b/cmd/pbkdf2.c
@@ -1,0 +1,145 @@
+/* vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80: */
+
+#include "jose.h"
+#include <jose/openssl.h>
+#include <string.h>
+#include <unistd.h>
+#define SUMMARY "Generates passphrases using PBKDF2"
+typedef struct {
+    unsigned char *salt;
+    unsigned char *hash;
+    char *iter;
+    FILE *input;
+} jcmd_opt_t;
+
+static const char *prefix = "jose pbkdf2 -i BIN [-I ITER] [-s SALT] [-a ALG]\n\n";
+
+static const jcmd_doc_t doc_input[] = {
+    { .arg = "FILE", .doc="Read data from FILE" },
+    { .arg = "-",    .doc="Read data from standard input" },
+    {}
+};
+
+static const jcmd_doc_t doc_iter[] = {
+    { .arg = "ITER", .doc="Number of PBKDF2 iterations" },
+    {}
+};
+
+static const jcmd_doc_t doc_salt[] = {
+    { .arg = "SALT", .doc="Specify salt as input to PBKDF2" },
+    {}
+};
+static const jcmd_doc_t doc_hash[] = {
+    { .arg = "ALG", .doc="Specify hash algorithm ALG for PBKDF2" },
+    {}
+};
+static bool
+jcmd_opt_set_str(const jcmd_cfg_t *cfg, void *vopt, const char *arg)
+{
+    const char **find = vopt;
+    *find = arg;
+    return true;
+}
+
+static void
+jcmd_opt_cleanup(jcmd_opt_t *opt)
+{
+    ;
+}
+
+static const jcmd_cfg_t cfgs[] = {
+    {
+        .opt = { "input", required_argument, .val = 'i' },
+        .off = offsetof(jcmd_opt_t, input),
+        .set = jcmd_opt_set_ifile,
+        .doc = doc_input,
+        .def = "-",
+    },
+    {
+        .opt = { "iteration_count", required_argument, .val = 'I'},
+        .off = offsetof(jcmd_opt_t, iter),
+        .set = jcmd_opt_set_str,
+        .doc = doc_iter,
+        .def = "4096",
+    },
+    {
+        .opt = { "salt", required_argument, .val = 's'},
+        .off = offsetof(jcmd_opt_t, salt),
+        .set = jcmd_opt_set_str,
+        .doc = doc_salt,
+    },
+    {
+        .opt = { "hash", required_argument, .val = 'a'},
+        .off = offsetof(jcmd_opt_t, hash),
+        .set = jcmd_opt_set_str,
+        .doc = doc_hash,
+        .def = "S256",
+    },
+    {}
+};
+
+static size_t
+str2enum(const char *str, ...)
+{
+    size_t i = 0;
+    va_list ap;
+
+    va_start(ap, str);
+
+    for (const char *v = NULL; (v = va_arg(ap, const char *)); i++) {
+        if (str && strcmp(str, v) == 0) {
+            va_end(ap);
+            return i;
+        }
+    }
+
+    va_end(ap);
+    return SIZE_MAX;
+}
+
+static int
+jcmd_pbkdf2(int argc, char *argv[])
+{
+    char pass[4096] = { 0 };
+    jcmd_opt_auto_t opt = {};
+
+    if (!jcmd_opt_parse(argc, argv, cfgs, &opt, prefix))
+        return EXIT_FAILURE;
+    uint64_t iter = strtoul(opt.iter,NULL,10);
+    size_t i = 0;
+
+    size_t ret = 0;
+    const EVP_MD *md=NULL;
+    if (! opt.salt) {
+        opt.salt = (unsigned char*) "NaCL is the chemical formula for salt!";
+    }
+    switch (str2enum((char*)opt.hash, "S512", "S384", "S256", "S224", "S1", NULL)) {
+    case 0: md = EVP_sha512(); break;
+    case 1: md = EVP_sha384(); break;
+    case 2: md = EVP_sha256(); break;
+    case 3: md = EVP_sha224(); break;
+    case 4: md = EVP_sha1();   break;
+    }
+    unsigned char result[EVP_MD_size(md)];
+
+    if (!md) {
+        fprintf(stderr, "Couldn't find hash alg: '%s'\n", opt.hash);
+        return EXIT_FAILURE;
+    }
+
+    while(!feof(opt.input)) {
+        ret = fread(&pass[i], 1, 1, opt.input);
+        i+=ret;
+        if (ferror(opt.input))
+            return EXIT_FAILURE;
+
+    }
+    PKCS5_PBKDF2_HMAC (pass, sizeof(pass) -1, opt.salt, sizeof(opt.salt)-1, iter, md, EVP_MD_size(md), result);
+    for (ssize_t j = 0; j < EVP_MD_size(md); j++) {
+        fprintf(stdout, "%c", result[j]);
+    }
+
+    return 0;
+}
+
+JCMD_REGISTER(SUMMARY, jcmd_pbkdf2, "pbkdf2")

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -2,6 +2,7 @@ man1_MANS = \
     ronn/jose.1 \
     ronn/jose-alg.1 \
     ronn/jose-fmt.1 \
+	ronn/jose-pbkdf2.1 \
     ronn/jose-b64-dec.1 \
     ronn/jose-b64-enc.1 \
     ronn/jose-jwe-dec.1 \

--- a/doc/ronn/jose-pbkdf2.1
+++ b/doc/ronn/jose-pbkdf2.1
@@ -1,0 +1,51 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "JOSE\-PBKDF2" "1" "April 2018" "" ""
+.
+.SH "NAME"
+\fBjose\-pbkdf2\fR \- Runs PBKDF2 over input
+.
+.SH "SYNOPSIS"
+\fBjose pbkdf2\fR \-i DATA [\-I ITER] [\-a ALG] [\-s SALT]
+.
+.SH "OVERVIEW"
+The \fBjose pbkdf2\fR command runs PBKDF2 over input text to generate keying material resistant to brute force attacks with configurable parameters\.
+.
+.SH "OPTIONS"
+.
+.TP
+\fB\-i\fR \fIFILE\fR, \fB\-\-input\fR=\fIFILE\fR
+Read input data from FILE
+.
+.TP
+\fB\-i\fR \-, \fB\-\-input\fR=\-
+Read input data from standard input
+.
+.TP
+\fB\-I\fR \fIITER\fR, \fB\-\-iter\fR=\fIITER\fR
+Set PBKDF2 iteration count to ITER
+.
+.TP
+\fB\-a\fR \fIALG\fR, \fB\-\-algorithm\fR=\fIALG\fR
+Use \fIALG\fR as the underlying hash algorithm for PBKDF2
+.
+.TP
+\fB\-s\fR \fISALT\fR, \fB\-\-salt\fR=\fISALT\fR
+Use \fISALT\fR as a salt input to the PBKDF2 instead of the default salt value
+.
+.SH "EXAMPLES"
+Use SHA\-256 as underlying hash algorithm for PBKDF2 over user supplied text:
+.
+.IP "" 4
+.
+.nf
+
+$ echo "User supplied strong passphrase" | jose pbkdf2 \-i\- \-a S256 > passdata\.out
+.
+.fi
+.
+.IP "" 0
+.
+.SH "AUTHOR"
+Max Tottenham <mtottenh@gmail\.com>

--- a/doc/ronn/jose-pbkdf2.1.html
+++ b/doc/ronn/jose-pbkdf2.1.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv='content-type' value='text/html;charset=utf8'>
+  <meta name='generator' value='Ronn/v0.7.3 (http://github.com/rtomayko/ronn/tree/0.7.3)'>
+  <title>jose-pbkdf2(1) - Runs PBKDF2 over input</title>
+  <style type='text/css' media='all'>
+  /* style: man */
+  body#manpage {margin:0}
+  .mp {max-width:100ex;padding:0 9ex 1ex 4ex}
+  .mp p,.mp pre,.mp ul,.mp ol,.mp dl {margin:0 0 20px 0}
+  .mp h2 {margin:10px 0 0 0}
+  .mp > p,.mp > pre,.mp > ul,.mp > ol,.mp > dl {margin-left:8ex}
+  .mp h3 {margin:0 0 0 4ex}
+  .mp dt {margin:0;clear:left}
+  .mp dt.flush {float:left;width:8ex}
+  .mp dd {margin:0 0 0 9ex}
+  .mp h1,.mp h2,.mp h3,.mp h4 {clear:left}
+  .mp pre {margin-bottom:20px}
+  .mp pre+h2,.mp pre+h3 {margin-top:22px}
+  .mp h2+pre,.mp h3+pre {margin-top:5px}
+  .mp img {display:block;margin:auto}
+  .mp h1.man-title {display:none}
+  .mp,.mp code,.mp pre,.mp tt,.mp kbd,.mp samp,.mp h3,.mp h4 {font-family:monospace;font-size:14px;line-height:1.42857142857143}
+  .mp h2 {font-size:16px;line-height:1.25}
+  .mp h1 {font-size:20px;line-height:2}
+  .mp {text-align:justify;background:#fff}
+  .mp,.mp code,.mp pre,.mp pre code,.mp tt,.mp kbd,.mp samp {color:#131211}
+  .mp h1,.mp h2,.mp h3,.mp h4 {color:#030201}
+  .mp u {text-decoration:underline}
+  .mp code,.mp strong,.mp b {font-weight:bold;color:#131211}
+  .mp em,.mp var {font-style:italic;color:#232221;text-decoration:none}
+  .mp a,.mp a:link,.mp a:hover,.mp a code,.mp a pre,.mp a tt,.mp a kbd,.mp a samp {color:#0000ff}
+  .mp b.man-ref {font-weight:normal;color:#434241}
+  .mp pre {padding:0 4ex}
+  .mp pre code {font-weight:normal;color:#434241}
+  .mp h2+pre,h3+pre {padding-left:0}
+  ol.man-decor,ol.man-decor li {margin:3px 0 10px 0;padding:0;float:left;width:33%;list-style-type:none;text-transform:uppercase;color:#999;letter-spacing:1px}
+  ol.man-decor {width:100%}
+  ol.man-decor li.tl {text-align:left}
+  ol.man-decor li.tc {text-align:center;letter-spacing:4px}
+  ol.man-decor li.tr {text-align:right;float:right}
+  </style>
+</head>
+<!--
+  The following styles are deprecated and will be removed at some point:
+  div#man, div#man ol.man, div#man ol.head, div#man ol.man.
+
+  The .man-page, .man-decor, .man-head, .man-foot, .man-title, and
+  .man-navigation should be used instead.
+-->
+<body id='manpage'>
+  <div class='mp' id='man'>
+
+  <div class='man-navigation' style='display:none'>
+    <a href="#NAME">NAME</a>
+    <a href="#SYNOPSIS">SYNOPSIS</a>
+    <a href="#OVERVIEW">OVERVIEW</a>
+    <a href="#OPTIONS">OPTIONS</a>
+    <a href="#EXAMPLES">EXAMPLES</a>
+    <a href="#AUTHOR">AUTHOR</a>
+  </div>
+
+  <ol class='man-decor man-head man head'>
+    <li class='tl'>jose-pbkdf2(1)</li>
+    <li class='tc'></li>
+    <li class='tr'>jose-pbkdf2(1)</li>
+  </ol>
+
+  <h2 id="NAME">NAME</h2>
+<p class="man-name">
+  <code>jose-pbkdf2</code> - <span class="man-whatis">Runs PBKDF2 over input</span>
+</p>
+
+<h2 id="SYNOPSIS">SYNOPSIS</h2>
+
+<p><code>jose pbkdf2</code> -i DATA [-I ITER] [-a ALG] [-s SALT]</p>
+
+<h2 id="OVERVIEW">OVERVIEW</h2>
+
+<p>The <code>jose pbkdf2</code> command runs PBKDF2 over input text to generate keying
+material resistant to brute force attacks with configurable parameters.</p>
+
+<h2 id="OPTIONS">OPTIONS</h2>
+
+<dl>
+<dt><code>-i</code> <em>FILE</em>, <code>--input</code>=<em>FILE</em> </dt><dd><p>Read input data from FILE</p></dd>
+<dt><code>-i</code> -, <code>--input</code>=- </dt><dd><p>Read input data from standard input</p></dd>
+<dt><code>-I</code> <em>ITER</em>, <code>--iter</code>=<em>ITER</em> </dt><dd><p>Set PBKDF2 iteration count to ITER</p></dd>
+<dt><code>-a</code> <em>ALG</em>, <code>--algorithm</code>=<em>ALG</em> </dt><dd><p>Use <em>ALG</em> as the underlying hash algorithm for PBKDF2</p></dd>
+<dt><code>-s</code> <em>SALT</em>, <code>--salt</code>=<em>SALT</em> </dt><dd><p>Use <em>SALT</em> as a salt input to the PBKDF2 instead of the default salt value</p></dd>
+</dl>
+
+
+<h2 id="EXAMPLES">EXAMPLES</h2>
+
+<p>Use SHA-256 as underlying hash algorithm for PBKDF2 over user supplied text:</p>
+
+<pre><code>$ echo "User supplied strong passphrase" | jose pbkdf2 -i- -a S256 &gt; passdata.out
+</code></pre>
+
+<h2 id="AUTHOR">AUTHOR</h2>
+
+<p>Max Tottenham &lt;mtottenh@gmail.com&gt;</p>
+
+
+  <ol class='man-decor man-foot man foot'>
+    <li class='tl'></li>
+    <li class='tc'>April 2018</li>
+    <li class='tr'>jose-pbkdf2(1)</li>
+  </ol>
+
+  </div>
+</body>
+</html>

--- a/doc/ronn/jose-pbkdf2.1.md
+++ b/doc/ronn/jose-pbkdf2.1.md
@@ -1,0 +1,38 @@
+jose-pbkdf2(1) -- Runs PBKDF2 over input
+========================================
+
+## SYNOPSIS
+
+`jose pbkdf2` -i DATA [-I ITER] [-a ALG] [-s SALT]
+
+## OVERVIEW
+
+The `jose pbkdf2` command runs PBKDF2 over input text to generate keying
+material resistant to brute force attacks with configurable parameters.
+
+## OPTIONS
+
+* `-i` _FILE_, `--input`=_FILE_ :
+  Read input data from FILE
+
+* `-i` -, `--input`=- :
+  Read input data from standard input
+
+* `-I` _ITER_, `--iter`=_ITER_ :
+  Set PBKDF2 iteration count to ITER
+
+* `-a` _ALG_, `--algorithm`=_ALG_ :
+  Use _ALG_ as the underlying hash algorithm for PBKDF2
+
+* `-s` _SALT_, `--salt`=_SALT_ :
+  Use _SALT_ as a salt input to the PBKDF2 instead of the default salt value
+
+## EXAMPLES
+
+Use SHA-256 as underlying hash algorithm for PBKDF2 over user supplied text:
+
+    $ echo "User supplied strong passphrase" | jose pbkdf2 -i- -a S256 > passdata.out
+
+## AUTHOR
+
+Max Tottenham &lt;mtottenh@gmail.com&gt;


### PR DESCRIPTION
While toying around with clevis I found it useful to be able to run pbkdf2 over some user supplied data to generate keying material (I was using a yubikey's HMAC-SHA1 and wanted a way of padding the response to a fixed length). Of course it would be possible to split this out into a small separate utility, but at the time I added it to jose as I was already working in it and it has a nice command line arg parser etc. 

If it's not worth upstreaming I'll split this out into a separate utility or rethink how the clevis yubikey plugin should work.