### PR TITLE
Add support for LibreSSL

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -6,7 +6,7 @@ if not cc.links(code, args: flags, name: '-Wl,--version-script=...')
   flags = [ '-export-symbols-regex=^jose_.*' ]
 endif
 
-libjose = library('jose',
+libjose_sources = [
   'misc.c',           'misc.h',
   'cfg.c',
   'io.c',
@@ -38,7 +38,21 @@ libjose = library('jose',
   'openssl/rsa.c',
   'openssl/rsaes.c',
   'openssl/rsassa.c',
+]
 
+if cc.compiles('''
+    #include <tls.h>
+    int main(void) {
+        tls_config_set_ca_mem(NULL, NULL, 0);
+        return 0;
+    }
+''')
+   libjose_sources += ['openssl/libressl_evp.c']
+endif
+
+
+libjose = library('jose',
+  libjose_sources,
   dependencies: [zlib, jansson, libcrypto, threads],
   version: '0.0.0',
   link_args: flags,

--- a/lib/openssl/aescbch.c
+++ b/lib/openssl/aescbch.c
@@ -181,7 +181,7 @@ enc_done(jose_io_t *io)
     uint8_t tg[EVP_MD_size(HMAC_CTX_get_md(i->hctx))];
     int l = 0;
 
-    if (EVP_EncryptFinal(i->cctx, ct, &l) <= 0)
+    if (EVP_EncryptFinal_ex(i->cctx, ct, &l) <= 0)
         return false;
 
     if (!i->next->feed(i->next, ct, l) || !i->next->done(i->next))
@@ -259,7 +259,7 @@ dec_done(jose_io_t *io)
     if (CRYPTO_memcmp(tg, bf, sizeof(bf)) != 0)
         return false;
 
-    if (EVP_DecryptFinal(i->cctx, pt, &l) <= 0)
+    if (EVP_DecryptFinal_ex(i->cctx, pt, &l) <= 0)
         return false;
 
     if (!i->next->feed(i->next, pt, l) || !i->next->done(i->next)) {

--- a/lib/openssl/aesgcm.c
+++ b/lib/openssl/aesgcm.c
@@ -127,7 +127,7 @@ enc_done(jose_io_t *io)
     uint8_t tg[EVP_GCM_TLS_TAG_LEN] = {};
     int l = 0;
 
-    if (EVP_EncryptFinal(i->cctx, ct, &l) <= 0)
+    if (EVP_EncryptFinal_ex(i->cctx, ct, &l) <= 0)
         return false;
 
     if (!i->next->feed(i->next, ct, l) || !i->next->done(i->next))
@@ -190,7 +190,7 @@ dec_done(jose_io_t *io)
                             sizeof(tg), tg) <= 0)
         return false;
 
-    if (EVP_DecryptFinal(i->cctx, pt, &l) <= 0)
+    if (EVP_DecryptFinal_ex(i->cctx, pt, &l) <= 0)
         return false;
 
     if (!i->next->feed(i->next, pt, l) || !i->next->done(i->next)) {

--- a/lib/openssl/aeskw.c
+++ b/lib/openssl/aeskw.c
@@ -24,6 +24,10 @@
 
 #include <string.h>
 
+#if defined(LIBRESSL_VERSION_NUMBER)
+#include "libressl_evp.h"
+#endif
+
 #define NAMES "A128KW", "A192KW", "A256KW"
 
 static json_int_t
@@ -168,7 +172,7 @@ alg_wrap_wrp(const jose_hook_alg_t *alg, jose_cfg_t *cfg, json_t *jwe,
         goto egress;
     ctl = len;
 
-    if (EVP_EncryptFinal(ecc, &ct[len], &len) <= 0)
+    if (EVP_EncryptFinal_ex(ecc, &ct[len], &len) <= 0)
         goto egress;
     ctl += len;
 
@@ -235,7 +239,7 @@ alg_wrap_unw(const jose_hook_alg_t *alg, jose_cfg_t *cfg, const json_t *jwe,
         goto egress;
     ptl = len;
 
-    if (EVP_DecryptFinal(ecc, &pt[len], &len) <= 0)
+    if (EVP_DecryptFinal_ex(ecc, &pt[len], &len) <= 0)
         goto egress;
     ptl += len;
 

--- a/lib/openssl/compat.c
+++ b/lib/openssl/compat.c
@@ -17,7 +17,7 @@
 
 #include "compat.h"
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 const unsigned char *
 EVP_PKEY_get0_hmac(EVP_PKEY *pkey, size_t *len)
 {

--- a/lib/openssl/compat.h
+++ b/lib/openssl/compat.h
@@ -23,7 +23,7 @@
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 const unsigned char *
 EVP_PKEY_get0_hmac(EVP_PKEY *pkey, size_t *len);
 

--- a/lib/openssl/libressl_evp.c
+++ b/lib/openssl/libressl_evp.c
@@ -1,0 +1,220 @@
+/* ====================================================================
+ * Copyright (c) 2001-2018 The OpenSSL Project.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. All advertising materials mentioning features or use of this
+ *    software must display the following acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+ *
+ * 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For written permission, please contact
+ *    openssl-core@openssl.org.
+ *
+ * 5. Products derived from this software may not be called "OpenSSL"
+ *    nor may "OpenSSL" appear in their names without prior written
+ *    permission of the OpenSSL Project.
+ *
+ * 6. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+ * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ *
+ */
+/* This code is from openssl 1.0.2r */
+#include <string.h>
+#include <openssl/opensslconf.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include "libressl_evp.h"
+
+static const unsigned char default_iv[] = {
+    0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6,
+};
+
+static size_t CRYPTO_128_wrap(void *key, const unsigned char *iv,
+                       unsigned char *out,
+                       const unsigned char *in, size_t inlen,
+                       block128_f block)
+{
+    unsigned char *A, B[16], *R;
+    size_t i, j, t;
+    if ((inlen & 0x7) || (inlen < 8) || (inlen > CRYPTO128_WRAP_MAX))
+        return 0;
+    A = B;
+    t = 1;
+    memmove(out + 8, in, inlen);
+    if (!iv)
+        iv = default_iv;
+
+    memcpy(A, iv, 8);
+
+    for (j = 0; j < 6; j++) {
+        R = out + 8;
+        for (i = 0; i < inlen; i += 8, t++, R += 8) {
+            memcpy(B + 8, R, 8);
+            block(B, B, key);
+            A[7] ^= (unsigned char)(t & 0xff);
+            if (t > 0xff) {
+                A[6] ^= (unsigned char)((t >> 8) & 0xff);
+                A[5] ^= (unsigned char)((t >> 16) & 0xff);
+                A[4] ^= (unsigned char)((t >> 24) & 0xff);
+            }
+            memcpy(R, B + 8, 8);
+        }
+    }
+    memcpy(out, A, 8);
+    return inlen + 8;
+}
+
+static size_t CRYPTO_128_unwrap(void *key, const unsigned char *iv,
+                         unsigned char *out,
+                         const unsigned char *in, size_t inlen,
+                         block128_f block)
+{
+    unsigned char *A, B[16], *R;
+    size_t i, j, t;
+    inlen -= 8;
+    if ((inlen & 0x7) || (inlen < 16) || (inlen > CRYPTO128_WRAP_MAX))
+        return 0;
+    A = B;
+    t = 6 * (inlen >> 3);
+    memcpy(A, in, 8);
+    memmove(out, in + 8, inlen);
+    for (j = 0; j < 6; j++) {
+        R = out + inlen - 8;
+        for (i = 0; i < inlen; i += 8, t--, R -= 8) {
+            A[7] ^= (unsigned char)(t & 0xff);
+            if (t > 0xff) {
+                A[6] ^= (unsigned char)((t >> 8) & 0xff);
+                A[5] ^= (unsigned char)((t >> 16) & 0xff);
+                A[4] ^= (unsigned char)((t >> 24) & 0xff);
+            }
+            memcpy(B + 8, R, 8);
+            block(B, B, key);
+            memcpy(R, B + 8, 8);
+        }
+    }
+    if (!iv)
+        iv = default_iv;
+    if (memcmp(A, iv, 8)) {
+        OPENSSL_cleanse(out, inlen);
+        return 0;
+    }
+    return inlen;
+}
+
+static int aes_wrap_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
+                             const unsigned char *iv, int enc)
+{
+    EVP_AES_WRAP_CTX *wctx = ctx->cipher_data;
+    if (!iv && !key)
+	return 1;
+    if (key) {
+        if (ctx->encrypt)
+            AES_set_encrypt_key(key, ctx->key_len * 8, &wctx->ks.ks);
+        else
+            AES_set_decrypt_key(key, ctx->key_len * 8, &wctx->ks.ks);
+        if (!iv)
+            wctx->iv = NULL;
+}
+    if (iv) {
+        memcpy(ctx->iv, iv, 8);
+        wctx->iv = ctx->iv;
+    }
+    return 1;
+}
+
+static int aes_wrap_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                           const unsigned char *in, size_t inlen)
+{
+    EVP_AES_WRAP_CTX *wctx = ctx->cipher_data;
+    size_t rv;
+    if (!in)
+        return 0;
+    if (inlen % 8)
+        return -1;
+    if (ctx->encrypt && inlen < 8)
+        return -1;
+    if (!ctx->encrypt && inlen < 16)
+        return -1;
+    if (!out) {
+        if (ctx->encrypt)
+            return inlen + 8;
+        else
+            return inlen - 8;
+    }
+    if (ctx->encrypt)
+        rv = CRYPTO_128_wrap(&wctx->ks.ks, wctx->iv, out, in, inlen,
+                             (block128_f) AES_encrypt);
+    else
+        rv = CRYPTO_128_unwrap(&wctx->ks.ks, wctx->iv, out, in, inlen,
+                               (block128_f) AES_decrypt);
+    return rv ? (int)rv : -1;
+}
+
+static const EVP_CIPHER aes_128_wrap = {
+    NID_id_aes128_wrap,
+    8, 16, 8, WRAP_FLAGS,
+    aes_wrap_init_key, aes_wrap_cipher,
+    NULL,
+    sizeof(EVP_AES_WRAP_CTX),
+    NULL, NULL, NULL, NULL
+
+};
+
+const EVP_CIPHER *EVP_aes_128_wrap(void){
+	return &aes_128_wrap;
+}
+
+static const EVP_CIPHER aes_192_wrap = {
+    NID_id_aes192_wrap,
+    8, 24, 8, WRAP_FLAGS,
+    aes_wrap_init_key, aes_wrap_cipher,
+    NULL,
+    sizeof(EVP_AES_WRAP_CTX),
+    NULL, NULL, NULL, NULL
+};
+
+const EVP_CIPHER *EVP_aes_192_wrap(void){
+	return &aes_192_wrap;
+}
+
+static const EVP_CIPHER aes_256_wrap = {
+    NID_id_aes256_wrap,
+    8, 32, 8, WRAP_FLAGS,
+    aes_wrap_init_key, aes_wrap_cipher,
+    NULL,
+    sizeof(EVP_AES_WRAP_CTX),
+    NULL, NULL, NULL, NULL
+};
+
+const EVP_CIPHER *EVP_aes_256_wrap(void) {
+	return &aes_256_wrap;
+}

--- a/lib/openssl/libressl_evp.h
+++ b/lib/openssl/libressl_evp.h
@@ -1,0 +1,78 @@
+/* ====================================================================
+ * Copyright (c) 2001-2018 The OpenSSL Project.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. All advertising materials mentioning features or use of this
+ *    software must display the following acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+ *
+ * 4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For written permission, please contact
+ *    openssl-core@openssl.org.
+ *
+ * 5. Products derived from this software may not be called "OpenSSL"
+ *    nor may "OpenSSL" appear in their names without prior written
+ *    permission of the OpenSSL Project.
+ *
+ * 6. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+ * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * ====================================================================
+ *
+ */
+
+#include <openssl/opensslconf.h>
+#include <openssl/modes.h>
+#include <openssl/aes.h>
+#include <openssl/asn1.h>
+
+/*Wrap mode macros.*/
+#define EVP_CIPH_WRAP_MODE               0x10002
+#define EVP_PKEY_CTRL_GET_MD             13
+#define	EVP_CIPHER_CTX_FLAG_WRAP_ALLOW   0x1
+#define CRYPTO128_WRAP_MAX               (1UL << 31)
+
+#define WRAP_FLAGS      (EVP_CIPH_WRAP_MODE \
+                | EVP_CIPH_CUSTOM_IV | EVP_CIPH_FLAG_CUSTOM_CIPHER \
+                | EVP_CIPH_ALWAYS_CALL_INIT | EVP_CIPH_FLAG_DEFAULT_ASN1)
+
+typedef struct {
+    union {
+        double align;
+        AES_KEY ks;
+    } ks;
+    /* Indicates if IV has been set */
+    unsigned char *iv;
+} EVP_AES_WRAP_CTX;
+
+
+const EVP_CIPHER *EVP_aes_128_wrap(void);
+const EVP_CIPHER *EVP_aes_192_wrap(void);
+const EVP_CIPHER *EVP_aes_256_wrap(void);

--- a/lib/openssl/lock.c
+++ b/lib/openssl/lock.c
@@ -17,7 +17,7 @@
 
 #include <openssl/crypto.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 
 #include <pthread.h>
 


### PR DESCRIPTION
LibreSSL is almost a drop in replacement for OpenSSL 1.0. However; there are
a few issues that must be taken care of to make it work with jose:

  - LibreSSL sets the OPENSSL_VERSION_NUMBER macro to 0x2xxxxxxL, which is
    greater than 0x10100000L, this will cause checks for OPENSL_VERSION_NUMBER
    less than 0x10100000L to fail. However, LibreSSL also provides a
    LIBRESSL_VERSION_NUMBER macro which can be used to check if LibreSSL is
    installed.

  - Add two files: libressl_evp.h and libressl_evp.c to lib/openssl.
    The logic in these files are taken from openssl-1.0.2r and add the
    following APIs that LibreSSL is missing:
      EVP_aes_128_wrap
      EVP_aes_192_wrap
      EVP_aes_256_wrap
    No code has been modified from the original openssl-1.0.2r source.

  - In lib/meson.build, check if the tls.h header contains tls_config_set_ca_mem
    which is unique to LibreSSL.

  - If the test program compiles, then add openssl/libressl_evp.c to the
    libjose_sources array.

  - Use EVP_EncryptFinal_ex and EVP_DecryptFinal_ex instead of
    EVP_EncryptFinal and EVP_DecryptFinal. These changes avoid warnings from
    LibreSSL when linking about how EVP_EncryptFinal and EVP_DecryptFinal are
    misused often and to use the _ex variants instead.

Tested against OpenSSL 1.0.2r, 1.1.1a, and LibreSSL 2.8.3.