### PR TITLE
José manpages have forward apostrophes instead of ASCII ones

### DIFF
--- a/doc/ronn/jose-alg.1
+++ b/doc/ronn/jose-alg.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JOSE\-ALG" "1" "June 2017" "" ""
+.TH "JOSE\-ALG" "1" "July 2019" "" ""
 .
 .SH "NAME"
 \fBjose\-alg\fR \- Lists all supported algorithms

--- a/doc/ronn/jose-b64-dec.1
+++ b/doc/ronn/jose-b64-dec.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JOSE\-B64\-DEC" "1" "June 2017" "" ""
+.TH "JOSE\-B64\-DEC" "1" "July 2019" "" ""
 .
 .SH "NAME"
 \fBjose\-b64\-dec\fR \- Decodes URL\-safe Base64 data to binary

--- a/doc/ronn/jose-b64-enc.1
+++ b/doc/ronn/jose-b64-enc.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JOSE\-B64\-ENC" "1" "June 2017" "" ""
+.TH "JOSE\-B64\-ENC" "1" "July 2019" "" ""
 .
 .SH "NAME"
 \fBjose\-b64\-enc\fR \- Encodes binary data to URL\-safe Base64

--- a/doc/ronn/jose-fmt.1
+++ b/doc/ronn/jose-fmt.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JOSE\-FMT" "1" "June 2017" "" ""
+.TH "JOSE\-FMT" "1" "August 2019" "" ""
 .
 .SH "NAME"
 \fBjose\-fmt\fR \- Converts JSON between serialization formats
@@ -237,7 +237,7 @@ Change the algorithm in a JWK:
 .
 .nf
 
-$ echo "$jwk" | jose fmt \-j\- \-j \'"A128GCM"\' \-s alg \-Uo\-
+$ echo "$jwk" | jose fmt \-j\- \-j \(cq"A128GCM"\(cq \-s alg \-Uo\-
 {"kty":"oct","alg":"A128GCM",\.\.\.}
 .
 .fi
@@ -251,7 +251,7 @@ Build a JWE template:
 .
 .nf
 
-$ jose fmt \-j \'{}\' \-cs unprotected \-q A128KW \-s alg \-UUo\-
+$ jose fmt \-j \(cq{}\(cq \-cs unprotected \-q A128KW \-s alg \-UUo\-
 {"unprotected":{"alg":"A128KW"}}
 .
 .fi

--- a/doc/ronn/jose-jwe-dec.1
+++ b/doc/ronn/jose-jwe-dec.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JOSE\-JWE\-DEC" "1" "May 2017" "" ""
+.TH "JOSE\-JWE\-DEC" "1" "July 2019" "" ""
 .
 .SH "NAME"
 \fBjose\-jwe\-dec\fR \- Decrypts a JWE using the supplied JWKs

--- a/doc/ronn/jose-jwe-enc.1
+++ b/doc/ronn/jose-jwe-enc.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JOSE\-JWE\-ENC" "1" "May 2017" "" ""
+.TH "JOSE\-JWE\-ENC" "1" "August 2019" "" ""
 .
 .SH "NAME"
 \fBjose\-jwe\-enc\fR \- Encrypts plaintext using one or more JWK/password
@@ -66,7 +66,7 @@ Read JWK(Set) from FILE
 Read JWK(Set) from standard input
 .
 .TP
-\fB\-p\fR, `\-\-password
+\fB\-p\fR, \fB\-\-password\fR
 Prompt for an encryption password
 .
 .TP
@@ -96,7 +96,7 @@ Encrypt data with a symmetric key using JWE JSON Serialization:
 .
 .nf
 
-$ jose jwk gen \-i \'{"alg":"A128GCM"}\' \-o key\.jwk
+$ jose jwk gen \-i \(cq{"alg":"A128GCM"}\(cq \-o key\.jwk
 $ jose jwe enc \-I msg\.txt \-k key\.jwk \-o msg\.jwe
 .
 .fi
@@ -125,14 +125,14 @@ Compress plaintext before encryption:
 .
 .nf
 
-$ jose jwe enc \-i \'{"protected":{"zip":"DEF"}}\' \.\.\.
+$ jose jwe enc \-i \(cq{"protected":{"zip":"DEF"}}\(cq \.\.\.
 .
 .fi
 .
 .IP "" 0
 .
 .P
-Encrypt with two keys and two passwords: $ jose jwk gen \-i \'{"alg":"ECDH\-ES+A128KW"}\' \-o ec\.jwk $ jose jwk gen \-i \'{"alg":"RSA1_5"}\' \-o rsa\.jwk $ jose jwe enc \-I msg\.txt \-p \-k ec\.jwk \-p \-k rsa\.jwk \-o msg\.jwe Please enter a password: Please re\-enter the previous password: Please enter a password: Please re\-enter the previous password:
+Encrypt with two keys and two passwords: $ jose jwk gen \-i \(cq{"alg":"ECDH\-ES+A128KW"}\(cq \-o ec\.jwk $ jose jwk gen \-i \(cq{"alg":"RSA1_5"}\(cq \-o rsa\.jwk $ jose jwe enc \-I msg\.txt \-p \-k ec\.jwk \-p \-k rsa\.jwk \-o msg\.jwe Please enter a password: Please re\-enter the previous password: Please enter a password: Please re\-enter the previous password:
 .
 .SH "AUTHOR"
 Nathaniel McCallum <npmccallum@redhat\.com>

--- a/doc/ronn/jose-jwe-enc.1.html
+++ b/doc/ronn/jose-jwe-enc.1.html
@@ -123,7 +123,7 @@ and <code>-r</code> options should generally be used for providing extended JWE 
 <dt><code>-r</code> -, <code>--recipient</code>=- </dt><dd><p>Read JWE recipient template from standard input</p></dd>
 <dt><code>-k</code> <em>FILE</em>, <code>--key</code>=<em>FILE</em> </dt><dd><p>Read JWK(Set) from FILE</p></dd>
 <dt><code>-k</code> -, <code>--key</code>=- </dt><dd><p>Read JWK(Set) from standard input</p></dd>
-<dt><code>-p</code>, `--password </dt><dd><p>Prompt for an encryption password</p></dd>
+<dt><code>-p</code>, <code>--password</code> </dt><dd><p>Prompt for an encryption password</p></dd>
 <dt><code>-o</code> <em>FILE</em>, <code>--output</code>=<em>FILE</em> </dt><dd><p>Write JWE to FILE</p></dd>
 <dt><code>-o</code> -, <code>--output</code>=- </dt><dd><p>Write JWE to stdout (default)</p></dd>
 <dt><code>-O</code> <em>FILE</em>, <code>--detach</code>=<em>FILE</em> </dt><dd><p>Detach ciphertext and decode to FILE</p></dd>
@@ -173,7 +173,7 @@ Please re-enter the previous password:
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>May 2017</li>
+    <li class='tc'>August 2019</li>
     <li class='tr'>jose-jwe-enc(1)</li>
   </ol>
 

--- a/doc/ronn/jose-jwe-enc.1.md
+++ b/doc/ronn/jose-jwe-enc.1.md
@@ -69,7 +69,7 @@ and `-r` options should generally be used for providing extended JWE metadata.
 *  `-k` -, `--key`=- :
   Read JWK(Set) from standard input
 
-*  `-p`, `--password :
+*  `-p`, `--password` :
   Prompt for an encryption password
 
 *  `-o` _FILE_, `--output`=_FILE_ :

--- a/doc/ronn/jose-jwe-fmt.1
+++ b/doc/ronn/jose-jwe-fmt.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JOSE\-JWE\-FMT" "1" "May 2017" "" ""
+.TH "JOSE\-JWE\-FMT" "1" "July 2019" "" ""
 .
 .SH "NAME"
 \fBjose\-jwe\-fmt\fR \- Converts a JWE between serialization formats

--- a/doc/ronn/jose-jwk-eql.1
+++ b/doc/ronn/jose-jwk-eql.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JOSE\-JWK\-EQL" "1" "June 2017" "" ""
+.TH "JOSE\-JWK\-EQL" "1" "July 2019" "" ""
 .
 .SH "NAME"
 \fBjose\-jwk\-eql\fR \- Calculates the JWK thumbprint
@@ -10,7 +10,7 @@
 \fBjose jwk eql\fR \-i JWK \-i JWK
 .
 .SH "OVERVIEW"
-The \fBjose jwk eql\fR command determines whether two keys are equal\. It compares the same properties defined for use in a JWK thumbprint (RFC 7638)\. This means that optional metadata isn\'t considered for comparison\.
+The \fBjose jwk eql\fR command determines whether two keys are equal\. It compares the same properties defined for use in a JWK thumbprint (RFC 7638)\. This means that optional metadata isn\(cqt considered for comparison\.
 .
 .SH "OPTIONS"
 .
@@ -33,7 +33,7 @@ Generate a key and modify optional metadata then test equality:
 .
 .nf
 
-$ jose jwk gen \-i \'{"alg":"ES256"}\' \-o key\.jwk
+$ jose jwk gen \-i \(cq{"alg":"ES256"}\(cq \-o key\.jwk
 $ jose fmt \-j key\.jwk \-Od alg \-o mod\.jwk
 $ jose jwk eql \-i key\.jwk \-i mod\.jwk
 $ echo $?

--- a/doc/ronn/jose-jwk-exc.1
+++ b/doc/ronn/jose-jwk-exc.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JOSE\-JWK\-EXC" "1" "June 2017" "" ""
+.TH "JOSE\-JWK\-EXC" "1" "July 2019" "" ""
 .
 .SH "NAME"
 \fBjose\-jwk\-exc\fR \- Performs a key exchange using the two input keys
@@ -77,8 +77,8 @@ Perform a key exchange:
 .
 .nf
 
-$ jose jwk gen \-i \'{"alg":"ECDH"}\' \-o local\.jwk
-$ jose jwk gen \-i \'{"alg":"ECDH"}\' | jose jwk pub \-i\- \-o remote\.jwk
+$ jose jwk gen \-i \(cq{"alg":"ECDH"}\(cq \-o local\.jwk
+$ jose jwk gen \-i \(cq{"alg":"ECDH"}\(cq | jose jwk pub \-i\- \-o remote\.jwk
 $ jose jwk exc \-l local\.jwk \-r remote\.jwk \-o exchanged\.jwk
 .
 .fi

--- a/doc/ronn/jose-jwk-gen.1
+++ b/doc/ronn/jose-jwk-gen.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JOSE\-JWK\-GEN" "1" "June 2017" "" ""
+.TH "JOSE\-JWK\-GEN" "1" "July 2019" "" ""
 .
 .SH "NAME"
 \fBjose\-jwk\-gen\fR \- Creates a random JWK for each input JWK template
@@ -51,9 +51,9 @@ Generate three keys, each targeting a different algorithm:
 .
 .nf
 
-$ jose jwk gen \-i \'{"alg":"HS256"}\' \-o oct\.jwk
-$ jose jwk gen \-i \'{"alg":"RS256"}\' \-o rsa\.jwk
-$ jose jwk gen \-i \'{"alg":"ES256"}\' \-o ec\.jwk
+$ jose jwk gen \-i \(cq{"alg":"HS256"}\(cq \-o oct\.jwk
+$ jose jwk gen \-i \(cq{"alg":"RS256"}\(cq \-o rsa\.jwk
+$ jose jwk gen \-i \(cq{"alg":"ES256"}\(cq \-o ec\.jwk
 .
 .fi
 .
@@ -66,9 +66,9 @@ Generate three keys using key parameters rather than algorithms:
 .
 .nf
 
-$ jose jwk gen \-i \'{"kty":"oct","bytes":32}\' \-o oct\.jwk
-$ jose jwk gen \-i \'{"kty":"RSA","bits":4096}\' \-o rsa\.jwk
-$ jose jwk gen \-i \'{"kty":"EC","crv":"P\-256"}\' \-o ec\.jwk
+$ jose jwk gen \-i \(cq{"kty":"oct","bytes":32}\(cq \-o oct\.jwk
+$ jose jwk gen \-i \(cq{"kty":"RSA","bits":4096}\(cq \-o rsa\.jwk
+$ jose jwk gen \-i \(cq{"kty":"EC","crv":"P\-256"}\(cq \-o ec\.jwk
 .
 .fi
 .
@@ -82,7 +82,7 @@ Create multiple keys at once using a JWKSet template:
 .nf
 
 $ jose jwk gen \e
-  \-i \'{"keys":[{"alg":"HS256"},{"alg":"ES256"}]}\' \e
+  \-i \(cq{"keys":[{"alg":"HS256"},{"alg":"ES256"}]}\(cq \e
   \-o keys\.jwkset
 .
 .fi
@@ -97,8 +97,8 @@ Create multiple keys at once using multiple JWK templates:
 .nf
 
 $ jose jwk gen \e
-  \-i \'{"alg":"HS256"}\' \e
-  \-i \'{"alg":"ES256"}\' \e
+  \-i \(cq{"alg":"HS256"}\(cq \e
+  \-i \(cq{"alg":"ES256"}\(cq \e
   \-o keys\.jwkset
 .
 .fi

--- a/doc/ronn/jose-jwk-pub.1
+++ b/doc/ronn/jose-jwk-pub.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JOSE\-JWK\-PUB" "1" "June 2017" "" ""
+.TH "JOSE\-JWK\-PUB" "1" "July 2019" "" ""
 .
 .SH "NAME"
 \fBjose\-jwk\-pub\fR \- Cleans private keys from a JWK
@@ -48,7 +48,7 @@ Clean private key material from a JWK:
 .
 .nf
 
-$ jose jwk gen \-i \'{"alg":"ES256"}\' \-o prv\.jwk
+$ jose jwk gen \-i \(cq{"alg":"ES256"}\(cq \-o prv\.jwk
 $ cat prv\.jwk
 {"alg":"ES256","crv":"P\-256","key_ops":["sign","verify"],"kty":"EC", \.\.\.}
 $ jose jwk pub \-i prv\.jwk \-o pub\.jwk

--- a/doc/ronn/jose-jwk-thp.1
+++ b/doc/ronn/jose-jwk-thp.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JOSE\-JWK\-THP" "1" "June 2017" "" ""
+.TH "JOSE\-JWK\-THP" "1" "July 2019" "" ""
 .
 .SH "NAME"
 \fBjose\-jwk\-thp\fR \- Calculates the JWK thumbprint
@@ -53,7 +53,7 @@ Calculate the S1 thumbprint of a newly generated key:
 .
 .nf
 
-$ jose jwk gen \-i \'{"alg":"ES256"}\' \-a S1 | jose jwk thp \-i\-
+$ jose jwk gen \-i \(cq{"alg":"ES256"}\(cq \-a S1 | jose jwk thp \-i\-
 BzmSH6W8a8LlbQ1mD0iBJdYj4x4
 .
 .fi

--- a/doc/ronn/jose-jwk-use.1
+++ b/doc/ronn/jose-jwk-use.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JOSE\-JWK\-USE" "1" "June 2017" "" ""
+.TH "JOSE\-JWK\-USE" "1" "July 2019" "" ""
 .
 .SH "NAME"
 \fBjose\-jwk\-use\fR \- Validates a key for the specified use(s)
@@ -91,7 +91,7 @@ Examples of both success and failure from a private and public key:
 .
 .nf
 
-$ jose jwk gen \-i \'{"alg":"ES256"}\' \-o prv\.jwk
+$ jose jwk gen \-i \(cq{"alg":"ES256"}\(cq \-o prv\.jwk
 $ jose jwk pub \-i prv\.jwk \-o pub\.jwk
 $ jose jwk use \-i prv\.jwk \-u sign
 $ echo $?

--- a/doc/ronn/jose-jws-fmt.1
+++ b/doc/ronn/jose-jws-fmt.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JOSE\-JWS\-FMT" "1" "June 2017" "" ""
+.TH "JOSE\-JWS\-FMT" "1" "July 2019" "" ""
 .
 .SH "NAME"
 \fBjose\-jws\-fmt\fR \- Converts a JWS between serialization formats

--- a/doc/ronn/jose-jws-sig.1
+++ b/doc/ronn/jose-jws-sig.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JOSE\-JWS\-SIG" "1" "June 2017" "" ""
+.TH "JOSE\-JWS\-SIG" "1" "July 2019" "" ""
 .
 .SH "NAME"
 \fBjose\-jws\-sig\fR \- Signs a payload using one or more JWKs
@@ -99,7 +99,7 @@ Sign data with a symmetric key using JWE JSON Serialization:
 .
 .nf
 
-$ jose jwk gen \-i \'{"alg":"HS256"}\' \-o key\.jwk
+$ jose jwk gen \-i \(cq{"alg":"HS256"}\(cq \-o key\.jwk
 $ jose jws sig \-I msg\.txt \-k key\.jwk \-o msg\.jws
 .
 .fi
@@ -126,8 +126,8 @@ Sign with two keys:
 .
 .nf
 
-$ jose jwk gen \-i \'{"alg":"ES256"}\' \-o ec\.jwk
-$ jose jwk gen \-i \'{"alg":"RS256"}\' \-o rsa\.jwk
+$ jose jwk gen \-i \(cq{"alg":"ES256"}\(cq \-o ec\.jwk
+$ jose jwk gen \-i \(cq{"alg":"RS256"}\(cq \-o rsa\.jwk
 $ jose jws sig \-I msg\.txt \-k ec\.jwk \-k rsa\.jwk \-o msg\.jws
 .
 .fi

--- a/doc/ronn/jose-jws-ver.1
+++ b/doc/ronn/jose-jws-ver.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JOSE\-JWS\-VER" "1" "May 2017" "" ""
+.TH "JOSE\-JWS\-VER" "1" "July 2019" "" ""
 .
 .SH "NAME"
 \fBjose\-jws\-ver\fR \- Verifies a JWS using the supplied JWKs

--- a/doc/ronn/jose.1
+++ b/doc/ronn/jose.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "JOSE" "1" "May 2017" "" ""
+.TH "JOSE" "1" "July 2019" "" ""
 .
 .SH "NAME"
 \fBjose\fR \- Toolkit for performing JSON Object Signing and Encryption


### PR DESCRIPTION
Do not escape single quotes, as they will appear as forward apostrophes
(0xc2b4) instead of ASCII ones (0x27) in the man pages.

This can be verified in a Fedora/RHEL system by running the following:
rpm -qla jose | grep '/man/' | xargs -n1 man -P cat | grep -e '`' -e '´'

The above command produces the following output on both Fedora with
jose-10-4.fc30.x86_64 and on RHEL8 with jose-10-2.el8.x86_64:

$ echo "$jwk" | jose fmt -j- -j ´"A128GCM"´ -s alg -Uo-
$ jose fmt -j ´{}´ -cs unprotected -q A128KW -s alg -UUo-
-p, `--password
$ jose jwk gen -i ´{"alg":"A128GCM"}´ -o key.jwk
$ jose jwe enc -i ´{"protected":{"zip":"DEF"}}´ ...
Encrypt with two keys and two passwords: $ jose jwk gen -i ´{"alg":"ECDH-ES+A128KW"}´ -o ec.jwk $ jose jwk gen -i ´{"alg":"RSA1_5"}´  -o  rsa.jwk  $
$ jose jwk gen -i ´{"alg":"ECDH"}´ -o local.jwk
$ jose jwk gen -i ´{"alg":"ECDH"}´ | jose jwk pub -i- -o remote.jwk
$ jose jwk gen -i ´{"alg":"HS256"}´ -o oct.jwk
$ jose jwk gen -i ´{"alg":"RS256"}´ -o rsa.jwk
$ jose jwk gen -i ´{"alg":"ES256"}´ -o ec.jwk
$ jose jwk gen -i ´{"kty":"oct","bytes":32}´ -o oct.jwk
$ jose jwk gen -i ´{"kty":"RSA","bits":4096}´ -o rsa.jwk
$ jose jwk gen -i ´{"kty":"EC","crv":"P-256"}´ -o ec.jwk
-i ´{"keys":[{"alg":"HS256"},{"alg":"ES256"}]}´ \
-i ´{"alg":"HS256"}´ \
-i ´{"alg":"ES256"}´ \
$ jose jwk gen -i ´{"alg":"ES256"}´ -o prv.jwk
$ jose jwk gen -i ´{"alg":"ES256"}´ -a S1 | jose jwk thp -i-
$ jose jwk gen -i ´{"alg":"ES256"}´ -o prv.jwk
$ jose jwk gen -i ´{"alg":"HS256"}´ -o key.jwk
$ jose jwk gen -i ´{"alg":"ES256"}´ -o ec.jwk
$ jose jwk gen -i ´{"alg":"RS256"}´ -o rsa.jwk

After this commit, no output is observed from running the same command.