### PR TITLE
Added support for ppc64le build on Travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,14 @@
+sudo: required
+arch:
+  - amd64
+  - ppc64le
+os: linux
 language: c
+compiler:
+  - clang
+  - gcc
+
+services: docker
 
 matrix:
   include:
@@ -15,13 +25,11 @@ matrix:
         - DISTRO=osx:xcode8.3
         - PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig
 
-compiler:
-  - clang
-  - gcc
+  exclude:
+    - arch: ppc64le
+      env: 
+        - DISTRO=fedora:rawhide
 
-os: linux
-sudo: required
-services: docker
 env:
   matrix:
     - DISTRO=fedora:rawhide

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,6 @@ matrix:
         - DISTRO=osx:xcode8.3
         - PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig
 
-  exclude:
-    - arch: ppc64le
-      env: 
-        - DISTRO=fedora:rawhide
-
 env:
   matrix:
     - DISTRO=fedora:rawhide


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The complete travis build log can be seen here: https://travis-ci.com/github/sanjaymsh/jose/builds/184447352. I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Note: Fedora:rawhide for ppc64le has been excluded because respective image is not available in dockerhub.

Thanks !!