### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ compiler:
   - clang
   - gcc
 
+arch:
+  - amd64
+  - ppc64le
+
 os: linux
 sudo: required
 services: docker


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the PR and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/jose/builds/191879042

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj