### PR TITLE
Add ES256K support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ José is extensively tested against the RFC test vectors.
 | ES256              |    YES    |   Signature    |     EC   |
 | ES384              |    YES    |   Signature    |     EC   |
 | ES512              |    YES    |   Signature    |     EC   |
+| ES256K             |    YES    |   Signature    |     EC   |
 | PS256              |    YES    |   Signature    |    RSA   |
 | PS384              |    YES    |   Signature    |    RSA   |
 | PS512              |    YES    |   Signature    |    RSA   |

--- a/lib/openssl/ec.c
+++ b/lib/openssl/ec.c
@@ -48,10 +48,11 @@ jwk_make_execute(jose_cfg_t *cfg, json_t *jwk)
     if (json_unpack(jwk, "{s?s}", "crv", &crv) < 0)
         return false;
 
-    switch (str2enum(crv, "P-256", "P-384", "P-521", NULL)) {
+    switch (str2enum(crv, "P-256", "P-384", "P-521", "secp256k1", NULL)) {
     case 0: nid = NID_X9_62_prime256v1; break;
     case 1: nid = NID_secp384r1; break;
     case 2: nid = NID_secp521r1; break;
+    case 3: nid = NID_secp256k1; break;
     default: return false;
     }
 

--- a/lib/openssl/jwk.c
+++ b/lib/openssl/jwk.c
@@ -169,6 +169,7 @@ jose_openssl_jwk_from_EC_POINT(jose_cfg_t *cfg, const EC_GROUP *grp,
     case NID_X9_62_prime256v1: crv = "P-256"; break;
     case NID_secp384r1: crv = "P-384"; break;
     case NID_secp521r1: crv = "P-521"; break;
+    case NID_secp256k1: crv = "secp256k1"; break;
     default: return NULL;
     }
 
@@ -366,10 +367,11 @@ jose_openssl_jwk_to_EC_KEY(jose_cfg_t *cfg, const json_t *jwk)
     if (strcmp(kty, "EC") != 0)
         return NULL;
 
-    switch (str2enum(crv, "P-256", "P-384", "P-521", NULL)) {
+    switch (str2enum(crv, "P-256", "P-384", "P-521", "secp256k1", NULL)) {
     case 0: nid = NID_X9_62_prime256v1; break;
     case 1: nid = NID_secp384r1; break;
     case 2: nid = NID_secp521r1; break;
+    case 3: nid = NID_secp256k1; break;
     default: return NULL;
     }
 

--- a/tests/jose-jwk-gen
+++ b/tests/jose-jwk-gen
@@ -17,6 +17,7 @@ done
 jose jwk gen -i '{ "kty": "EC", "crv": "P-256" }'
 jose jwk gen -i '{ "kty": "EC", "crv": "P-384" }'
 jose jwk gen -i '{ "kty": "EC", "crv": "P-521" }'
+jose jwk gen -i '{ "kty": "EC", "crv": "secp256k1" }'
 
 jose jwk gen -i '{ "kty": "RSA", "bits": 3072 }'
 ! jose jwk gen -i '{ "kty": "RSA", "bits": 3072, "e": 257 }'


### PR DESCRIPTION
Unfortunately it doesn't seem like RFC 8812 provides any "worked" examples, unlike some of the other RFCs. This roundtrips successfully with the implementation I recently added to github.com/lestrrat-go/jwx.

There's also a libsecp256k1 library from the bitcoin project (https://github.com/bitcoin-core/secp256k1). However it doesn't seem to have a stable release, and it's unclear that the extra dependency would be worth it over openssl for this usage.

If this is accepted, I'd be happy to add EdDSA and x25519/x448 curve support.