### PR TITLE
Small changes to have jose build with openssl 3

### DIFF
--- a/lib/openssl/compat.h
+++ b/lib/openssl/compat.h
@@ -17,6 +17,12 @@
 
 #pragma once
 
+/* Don't warn about deprecated functions. */
+#ifndef OPENSSL_API_COMPAT
+  /* 0x10101000L == 1.1.1. */
+  #define OPENSSL_API_COMPAT 0x10101000L
+#endif
+
 #include <openssl/bn.h>
 #include <openssl/hmac.h>
 #include <openssl/ec.h>

--- a/tests/jose-jwk-gen
+++ b/tests/jose-jwk-gen
@@ -19,8 +19,11 @@ jose jwk gen -i '{ "kty": "EC", "crv": "P-384" }'
 jose jwk gen -i '{ "kty": "EC", "crv": "P-521" }'
 
 jose jwk gen -i '{ "kty": "RSA", "bits": 3072 }'
-jose jwk gen -i '{ "kty": "RSA", "bits": 3072, "e": 257 }'
-jose jwk gen -i '{ "kty": "RSA", "bits": 3072, "e": "AQE" }'
+! jose jwk gen -i '{ "kty": "RSA", "bits": 3072, "e": 257 }'
+! jose jwk gen -i '{ "kty": "RSA", "bits": 3072, "e": 65536 }'
+! jose jwk gen -i '{ "kty": "RSA", "bits": 3072, "e": 65537 }'
+! jose jwk gen -i '{ "kty": "RSA", "bits": 3072, "e": "AQE" }'   # 257.
+jose jwk gen -i '{ "kty": "RSA", "bits": 3072, "e": "AQAB"}'     # 65537.
 
 jose jwk gen -i '{ "kty": "oct", "bytes": 32 }'
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -29,7 +29,7 @@ progs = [
 ]
 
 e = environment()
-e.append('PATH', meson.current_build_dir() + '/../cmd', separator: ':')
+e.prepend('PATH', meson.current_build_dir() + '/../cmd', separator: ':')
 e.set('VECTORS', meson.current_source_dir() + '/vectors')
 
 foreach p: progs


### PR DESCRIPTION
* ~~Upcoming OpenSSL version 3 has deprecated several low level functions, many of which we use with jose.
Since we also have `-Werror` turned on, the warnings generated by using these deprecated functions cause the build to fail, so let's make it so these specific warnings do not make the build fail, and we will be able to still build with OpenSSL 3 while a proper port to it happens in the meantime.~~

* declare OPENSSL_API_COMPAT 1.1.1, so that there will be no warnings/errors when building with OpenSSL 3,
due to the deprecated functions we currently use

* Minor fix in the meson file for the tests, prepending to the PATH variable, instead of appending, so that we make sure to use the utilities we have just built instead of ones that may exist in the system

* Updated our RSA code to apply the same limitation OpenSSL 3 imposes on the RSA public exponent `e` - it can be either 3, for legacy purposes, or an odd integer greater than or equal to 65537
