### PR TITLE
Remove bashisms from tests

### DIFF
--- a/tests/jose-b64-dec
+++ b/tests/jose-b64-dec
@@ -1,9 +1,9 @@
 #!/bin/sh -ex
 
-[ "`echo -n | jose b64 dec -i-`" == "" ]
-[ `echo -n "Zg" | jose b64 dec -i-` == "f" ]
-[ `echo -n "Zm8" | jose b64 dec -i-` == "fo" ]
-[ `echo -n "Zm9v" | jose b64 dec -i-` == "foo" ]
-[ `echo -n "Zm9vYg" | jose b64 dec -i-` == "foob" ]
-[ `echo -n "Zm9vYmE" | jose b64 dec -i-` == "fooba" ]
-[ `echo -n "Zm9vYmFy" | jose b64 dec -i-` == "foobar" ]
+test "`printf "" | jose b64 dec -i-`" = ""
+test `printf "Zg" | jose b64 dec -i-` = "f"
+test `printf "Zm8" | jose b64 dec -i-` = "fo"
+test `printf "Zm9v" | jose b64 dec -i-` = "foo"
+test `printf "Zm9vYg" | jose b64 dec -i-` = "foob"
+test `printf "Zm9vYmE" | jose b64 dec -i-` = "fooba"
+test `printf "Zm9vYmFy" | jose b64 dec -i-` = "foobar"

--- a/tests/jose-b64-enc
+++ b/tests/jose-b64-enc
@@ -1,9 +1,9 @@
 #!/bin/sh -ex
 
-[ "`echo -n | jose b64 enc -I-`" == "" ]
-[ `echo -n "f" | jose b64 enc -I-` == "Zg" ]
-[ `echo -n "fo" | jose b64 enc -I-` == "Zm8" ]
-[ `echo -n "foo" | jose b64 enc -I-` == "Zm9v" ]
-[ `echo -n "foob" | jose b64 enc -I-` == "Zm9vYg" ]
-[ `echo -n "fooba" | jose b64 enc -I-` == "Zm9vYmE" ]
-[ `echo -n "foobar" | jose b64 enc -I-` == "Zm9vYmFy" ]
+test "`printf "" | jose b64 enc -I-`" = ""
+test `printf "f" | jose b64 enc -I-` = "Zg"
+test `printf "fo" | jose b64 enc -I-` = "Zm8"
+test `printf "foo" | jose b64 enc -I-` = "Zm9v"
+test `printf "foob" | jose b64 enc -I-` = "Zm9vYg"
+test `printf "fooba" | jose b64 enc -I-` = "Zm9vYmE"
+test `printf "foobar" | jose b64 enc -I-` = "Zm9vYmFy"

--- a/tests/jose-fmt
+++ b/tests/jose-fmt
@@ -56,75 +56,75 @@ jose fmt -j '"foo"' -j '"foo"' -E
 jose fmt -q foo -S -j '"foo"' -SE
 
 ! jose fmt -o-
-[ `jose fmt -j '{}' -o-` == "{}" ]
-[ `jose fmt -j '[1,2,3]' -f- | wc -l` == "3" ]
-[ `jose fmt -j '[1,2,3]' -f- | head -n 1` == "1" ]
-[ `jose fmt -j '[1,2,3]' -f- | tail -n 1` == "3" ]
-[ `jose fmt -j '{"a":1,"b":2}' -f- | wc -l` == "2" ]
-[ `jose fmt -j '{"a":1,"b":2}' -f- | head -n 1` == "a=1" ]
-[ `jose fmt -j '{"a":1,"b":2}' -f- | tail -n 1` == "b=2" ]
+test `jose fmt -j '{}' -o-` = "{}"
+test `jose fmt -j '[1,2,3]' -f- | wc -l` = "3"
+test `jose fmt -j '[1,2,3]' -f- | head -n 1` = "1"
+test `jose fmt -j '[1,2,3]' -f- | tail -n 1` = "3"
+test `jose fmt -j '{"a":1,"b":2}' -f- | wc -l` = "2"
+test `jose fmt -j '{"a":1,"b":2}' -f- | head -n 1` = "a=1"
+test `jose fmt -j '{"a":1,"b":2}' -f- | tail -n 1` = "b=2"
 
-[ "`jose fmt -j '"foo"' -u-`" == "foo" ]
+test "`jose fmt -j '"foo"' -u-`" = "foo"
 ! jose fmt -j 7 -u-
 
 ! jose fmt -c
-[ "`jose fmt -j '{}' -j '{"a":1}' -s x -j 7 -s a -UUo-`" == '{"x":{"a":7}}' ]
-[ "`jose fmt -j '{}' -j '{"a":1}' -s x -cj 7 -s a -UUUo-`" == '{"x":{"a":1}}' ]
+test "`jose fmt -j '{}' -j '{"a":1}' -s x -j 7 -s a -UUo-`" = '{"x":{"a":7}}'
+test "`jose fmt -j '{}' -j '{"a":1}' -s x -cj 7 -s a -UUUo-`" = '{"x":{"a":1}}'
 
-[ "`jose fmt -Qo-`" == "[]" ]
-[ "`jose fmt -j 7 -j 8 -j 9 -Qo-`" == "[9,8,7]" ]
+test "`jose fmt -Qo-`" = "[]"
+test "`jose fmt -j 7 -j 8 -j 9 -Qo-`" = "[9,8,7]"
 
 ! jose fmt -M 1
-[ "`jose fmt -j 1 -j 2 -j 3 -M 1 -o-`" == "2" ]
-[ "`jose fmt -j 1 -j 2 -j 3 -M 1 -Uo-`" == "3" ]
-[ "`jose fmt -j 1 -j 2 -j 3 -M 2 -o-`" == "2" ]
-[ "`jose fmt -j 1 -j 2 -j 3 -M 2 -Uo-`" == "1" ]
-[ "`jose fmt -j 1 -j 2 -j 3 -M 2 -UUo-`" == "3" ]
+test "`jose fmt -j 1 -j 2 -j 3 -M 1 -o-`" = "2"
+test "`jose fmt -j 1 -j 2 -j 3 -M 1 -Uo-`" = "3"
+test "`jose fmt -j 1 -j 2 -j 3 -M 2 -o-`" = "2"
+test "`jose fmt -j 1 -j 2 -j 3 -M 2 -Uo-`" = "1"
+test "`jose fmt -j 1 -j 2 -j 3 -M 2 -UUo-`" = "3"
 
 ! jose fmt -t 0
 ! jose fmt -j 7 -t 0
 ! jose fmt -j '{}' -t 0
-[ "`jose fmt -j '[1,2,3]' -t 0 -lo-`" == "0" ]
-[ "`jose fmt -j '[1,2,3]' -t 1 -lo-`" == "1" ]
-[ "`jose fmt -j '[1,2,3]' -t 2 -lo-`" == "2" ]
-[ "`jose fmt -j '[1,2,3]' -t 3 -lo-`" == "3" ]
-[ "`jose fmt -j '[1,2,3]' -t 4 -lo-`" == "3" ]
+test "`jose fmt -j '[1,2,3]' -t 0 -lo-`" = "0"
+test "`jose fmt -j '[1,2,3]' -t 1 -lo-`" = "1"
+test "`jose fmt -j '[1,2,3]' -t 2 -lo-`" = "2"
+test "`jose fmt -j '[1,2,3]' -t 3 -lo-`" = "3"
+test "`jose fmt -j '[1,2,3]' -t 4 -lo-`" = "3"
 
 ! jose fmt -i 0
 ! jose fmt -j '[]' -i 0
 ! jose fmt -j 7 -j 8 -i 0
-[ "`jose fmt -j '[1,2]' -j 3 -i 0 -Uo-`" == "[3,1,2]" ]
-[ "`jose fmt -j '[1,2]' -j 3 -i 1 -Uo-`" == "[1,3,2]" ]
-[ "`jose fmt -j '[1,2]' -j 3 -i 2 -Uo-`" == "[1,2,3]" ]
+test "`jose fmt -j '[1,2]' -j 3 -i 0 -Uo-`" = "[3,1,2]"
+test "`jose fmt -j '[1,2]' -j 3 -i 1 -Uo-`" = "[1,3,2]"
+test "`jose fmt -j '[1,2]' -j 3 -i 2 -Uo-`" = "[1,2,3]"
 
 ! jose fmt -a
 ! jose fmt -j '[]' -a
 ! jose fmt -j 7 -j 8 -a
-[ "`jose fmt -j '[1,2]' -j 3 -aUo-`" == "[1,2,3]" ]
-[ "`jose fmt -j '{"foo":1}' -j '{"foo":2,"bar":2}' -aUo-`" == '{"bar":2,"foo":1}' ]
+test "`jose fmt -j '[1,2]' -j 3 -aUo-`" = "[1,2,3]"
+test "`jose fmt -j '{"foo":1}' -j '{"foo":2,"bar":2}' -aUo-`" = '{"bar":2,"foo":1}'
 
 ! jose fmt -x
 ! jose fmt -j '[]' -x
 ! jose fmt -j 7 -j 8 -x
-[ "`jose fmt -j '[1,2]' -j '[3,4]' -xUo-`" == "[1,2,3,4]" ]
-[ "`jose fmt -j '{"foo":1}' -j '{"foo":2,"bar":2}' -xUo-`" == '{"bar":2,"foo":2}' ]
+test "`jose fmt -j '[1,2]' -j '[3,4]' -xUo-`" = "[1,2,3,4]"
+test "`jose fmt -j '{"foo":1}' -j '{"foo":2,"bar":2}' -xUo-`" = '{"bar":2,"foo":2}'
 
 ! jose fmt -d 0
 ! jose fmt -j 7 -d 0
 ! jose fmt -j '[]' -d 0
-[ "`jose fmt -j '[1,2]' -d 0 -o-`" == "[2]" ]
-[ "`jose fmt -j '[1,2]' -d 1 -o-`" == "[1]" ]
+test "`jose fmt -j '[1,2]' -d 0 -o-`" = "[2]"
+test "`jose fmt -j '[1,2]' -d 1 -o-`" = "[1]"
 
 ! jose fmt -l
 ! jose fmt -j 7 -l
-[ "`jose fmt -j '{}' -lo-`" == "0" ]
-[ "`jose fmt -j '{"foo":1}' -lo-`" == "1" ]
-[ "`jose fmt -j '{"foo":1,"bar":2}' -lo-`" == "2" ]
+test "`jose fmt -j '{}' -lo-`" = "0" 
+test "`jose fmt -j '{"foo":1}' -lo-`" = "1"
+test "`jose fmt -j '{"foo":1,"bar":2}' -lo-`" = "2"
 
 ! jose fmt -e
 ! jose fmt -j 7 -e
-[ "`jose fmt -j '[1,2,3,4]' -eo-`" == "[]" ]
-[ "`jose fmt -j '{"foo":1}' -eo-`" == "{}" ]
+test "`jose fmt -j '[1,2,3,4]' -eo-`" = "[]"
+test "`jose fmt -j '{"foo":1}' -eo-`" = "{}"
 
 ! jose fmt -g bar
 ! jose fmt -g 0
@@ -132,8 +132,8 @@ jose fmt -q foo -S -j '"foo"' -SE
 ! jose fmt -j 7 -g 0
 ! jose fmt -j '{"foo":1}' -g bar
 ! jose fmt -j '[]' -g 0
-[ "`jose fmt -j '{"foo":1}' -g foo -o-`" == "1" ]
-[ "`jose fmt -j '[1]' -g 0 -o-`" == "1" ]
+test "`jose fmt -j '{"foo":1}' -g foo -o-`" = "1"
+test "`jose fmt -j '[1]' -g 0 -o-`" = "1"
 
 ! jose fmt -s foo
 ! jose fmt -s 0
@@ -142,11 +142,11 @@ jose fmt -q foo -S -j '"foo"' -SE
 ! jose fmt -j 7 -j 8 -s foo
 ! jose fmt -j 7 -j 8 -s 0
 ! jose fmt -j '[]' -j 8 -s 0
-[ "`jose fmt -j '{}' -j 7 -s "foo" -Uo-`" == '{"foo":7}' ]
-[ "`jose fmt -j '[1,2]' -j 7 -s 0 -Uo-`" == '[7,2]' ]
-[ "`jose fmt -j '[1,2]' -j 7 -s 1 -Uo-`" == '[1,7]' ]
+test "`jose fmt -j '{}' -j 7 -s "foo" -Uo-`" = '{"foo":7}'
+test "`jose fmt -j '[1,2]' -j 7 -s 0 -Uo-`" = '[7,2]'
+test "`jose fmt -j '[1,2]' -j 7 -s 1 -Uo-`" = '[1,7]'
 
 ! jose fmt -y
 ! jose fmt -Y
-[ "`jose fmt -j '{}' -YSu-`" == "e30" ]
-[ "`jose fmt -j '"e30"' -yOo-`" == "{}" ]
+test "`jose fmt -j '{}' -YSu-`" = "e30"
+test "`jose fmt -j '"e30"' -yOo-`" = "{}"

--- a/tests/jose-jwe-dec
+++ b/tests/jose-jwe-dec
@@ -2,54 +2,54 @@
 
 prfx=$VECTORS/rfc7520_5
 
-test "`jose jwe dec -i $prfx.1.jwec  -k $prfx.1.jwk`"    == "`cat $prfx.1.pt`"
-test "`jose jwe dec -i $prfx.1.jwef  -k $prfx.1.jwk`"    == "`cat $prfx.1.pt`"
-test "`jose jwe dec -i $prfx.1.jweg  -k $prfx.1.jwk`"    == "`cat $prfx.1.pt`"
+test "`jose jwe dec -i $prfx.1.jwec  -k $prfx.1.jwk`"    = "`cat $prfx.1.pt`"
+test "`jose jwe dec -i $prfx.1.jwef  -k $prfx.1.jwk`"    = "`cat $prfx.1.pt`"
+test "`jose jwe dec -i $prfx.1.jweg  -k $prfx.1.jwk`"    = "`cat $prfx.1.pt`"
 
 if jose alg | grep -q OAEP; then
-    test "`jose jwe dec -i $prfx.2.jwec  -k $prfx.2.jwk`"    == "`cat $prfx.2.pt`"
-    test "`jose jwe dec -i $prfx.2.jwef  -k $prfx.2.jwk`"    == "`cat $prfx.2.pt`"
-    test "`jose jwe dec -i $prfx.2.jweg  -k $prfx.2.jwk`"    == "`cat $prfx.2.pt`"
+    test "`jose jwe dec -i $prfx.2.jwec  -k $prfx.2.jwk`"    = "`cat $prfx.2.pt`"
+    test "`jose jwe dec -i $prfx.2.jwef  -k $prfx.2.jwk`"    = "`cat $prfx.2.pt`"
+    test "`jose jwe dec -i $prfx.2.jweg  -k $prfx.2.jwk`"    = "`cat $prfx.2.pt`"
 fi
 
-test "`jose jwe dec -i $prfx.3.jwec  -k $prfx.3.pwd`"    == "`cat $prfx.3.pt`"
-test "`jose jwe dec -i $prfx.3.jwef  -k $prfx.3.pwd`"    == "`cat $prfx.3.pt`"
-test "`jose jwe dec -i $prfx.3.jweg  -k $prfx.3.pwd`"    == "`cat $prfx.3.pt`"
-test "`jose jwe dec -i $prfx.3.jwec  -k $prfx.3.jwk`"    == "`cat $prfx.3.pt`"
-test "`jose jwe dec -i $prfx.3.jwef  -k $prfx.3.jwk`"    == "`cat $prfx.3.pt`"
-test "`jose jwe dec -i $prfx.3.jweg  -k $prfx.3.jwk`"    == "`cat $prfx.3.pt`"
+test "`jose jwe dec -i $prfx.3.jwec  -k $prfx.3.pwd`"    = "`cat $prfx.3.pt`"
+test "`jose jwe dec -i $prfx.3.jwef  -k $prfx.3.pwd`"    = "`cat $prfx.3.pt`"
+test "`jose jwe dec -i $prfx.3.jweg  -k $prfx.3.pwd`"    = "`cat $prfx.3.pt`"
+test "`jose jwe dec -i $prfx.3.jwec  -k $prfx.3.jwk`"    = "`cat $prfx.3.pt`"
+test "`jose jwe dec -i $prfx.3.jwef  -k $prfx.3.jwk`"    = "`cat $prfx.3.pt`"
+test "`jose jwe dec -i $prfx.3.jweg  -k $prfx.3.jwk`"    = "`cat $prfx.3.pt`"
 
-test "`jose jwe dec -i $prfx.4.jwec  -k $prfx.4.jwk`"    == "`cat $prfx.4.pt`"
-test "`jose jwe dec -i $prfx.4.jwef  -k $prfx.4.jwk`"    == "`cat $prfx.4.pt`"
-test "`jose jwe dec -i $prfx.4.jweg  -k $prfx.4.jwk`"    == "`cat $prfx.4.pt`"
+test "`jose jwe dec -i $prfx.4.jwec  -k $prfx.4.jwk`"    = "`cat $prfx.4.pt`"
+test "`jose jwe dec -i $prfx.4.jwef  -k $prfx.4.jwk`"    = "`cat $prfx.4.pt`"
+test "`jose jwe dec -i $prfx.4.jweg  -k $prfx.4.jwk`"    = "`cat $prfx.4.pt`"
 
-test "`jose jwe dec -i $prfx.5.jwec  -k $prfx.5.jwk`"    == "`cat $prfx.5.pt`"
-test "`jose jwe dec -i $prfx.5.jweg  -k $prfx.5.jwk`"    == "`cat $prfx.5.pt`"
+test "`jose jwe dec -i $prfx.5.jwec  -k $prfx.5.jwk`"    = "`cat $prfx.5.pt`"
+test "`jose jwe dec -i $prfx.5.jweg  -k $prfx.5.jwk`"    = "`cat $prfx.5.pt`"
 
-test "`jose jwe dec -i $prfx.6.jwec  -k $prfx.6.jwk`"    == "`cat $prfx.6.pt`"
-test "`jose jwe dec -i $prfx.6.jweg  -k $prfx.6.jwk`"    == "`cat $prfx.6.pt`"
+test "`jose jwe dec -i $prfx.6.jwec  -k $prfx.6.jwk`"    = "`cat $prfx.6.pt`"
+test "`jose jwe dec -i $prfx.6.jweg  -k $prfx.6.jwk`"    = "`cat $prfx.6.pt`"
 
-test "`jose jwe dec -i $prfx.7.jwec  -k $prfx.7.jwk`"    == "`cat $prfx.7.pt`"
-test "`jose jwe dec -i $prfx.7.jwef  -k $prfx.7.jwk`"    == "`cat $prfx.7.pt`"
-test "`jose jwe dec -i $prfx.7.jweg  -k $prfx.7.jwk`"    == "`cat $prfx.7.pt`"
+test "`jose jwe dec -i $prfx.7.jwec  -k $prfx.7.jwk`"    = "`cat $prfx.7.pt`"
+test "`jose jwe dec -i $prfx.7.jwef  -k $prfx.7.jwk`"    = "`cat $prfx.7.pt`"
+test "`jose jwe dec -i $prfx.7.jweg  -k $prfx.7.jwk`"    = "`cat $prfx.7.pt`"
 
-test "`jose jwe dec -i $prfx.8.jwec  -k $prfx.8.jwk`"    == "`cat $prfx.8.pt`"
-test "`jose jwe dec -i $prfx.8.jwef  -k $prfx.8.jwk`"    == "`cat $prfx.8.pt`"
-test "`jose jwe dec -i $prfx.8.jweg  -k $prfx.8.jwk`"    == "`cat $prfx.8.pt`"
+test "`jose jwe dec -i $prfx.8.jwec  -k $prfx.8.jwk`"    = "`cat $prfx.8.pt`"
+test "`jose jwe dec -i $prfx.8.jwef  -k $prfx.8.jwk`"    = "`cat $prfx.8.pt`"
+test "`jose jwe dec -i $prfx.8.jweg  -k $prfx.8.jwk`"    = "`cat $prfx.8.pt`"
 
-test "`jose jwe dec -i $prfx.9.jwec  -k $prfx.9.jwk`"    == "`cat $prfx.9.pt`"
-test "`jose jwe dec -i $prfx.9.jwef  -k $prfx.9.jwk`"    == "`cat $prfx.9.pt`"
-test "`jose jwe dec -i $prfx.9.jweg  -k $prfx.9.jwk`"    == "`cat $prfx.9.pt`"
+test "`jose jwe dec -i $prfx.9.jwec  -k $prfx.9.jwk`"    = "`cat $prfx.9.pt`"
+test "`jose jwe dec -i $prfx.9.jwef  -k $prfx.9.jwk`"    = "`cat $prfx.9.pt`"
+test "`jose jwe dec -i $prfx.9.jweg  -k $prfx.9.jwk`"    = "`cat $prfx.9.pt`"
 
-test "`jose jwe dec -i $prfx.10.jwef -k $prfx.10.jwk`"   == "`cat $prfx.10.pt`"
-test "`jose jwe dec -i $prfx.10.jweg -k $prfx.10.jwk`"   == "`cat $prfx.10.pt`"
+test "`jose jwe dec -i $prfx.10.jwef -k $prfx.10.jwk`"   = "`cat $prfx.10.pt`"
+test "`jose jwe dec -i $prfx.10.jweg -k $prfx.10.jwk`"   = "`cat $prfx.10.pt`"
 
-test "`jose jwe dec -i $prfx.11.jwef -k $prfx.11.jwk`"   == "`cat $prfx.11.pt`"
-test "`jose jwe dec -i $prfx.11.jweg -k $prfx.11.jwk`"   == "`cat $prfx.11.pt`"
+test "`jose jwe dec -i $prfx.11.jwef -k $prfx.11.jwk`"   = "`cat $prfx.11.pt`"
+test "`jose jwe dec -i $prfx.11.jweg -k $prfx.11.jwk`"   = "`cat $prfx.11.pt`"
 
-test "`jose jwe dec -i $prfx.12.jwef -k $prfx.12.jwk`"   == "`cat $prfx.12.pt`"
-test "`jose jwe dec -i $prfx.12.jweg -k $prfx.12.jwk`"   == "`cat $prfx.12.pt`"
+test "`jose jwe dec -i $prfx.12.jwef -k $prfx.12.jwk`"   = "`cat $prfx.12.pt`"
+test "`jose jwe dec -i $prfx.12.jweg -k $prfx.12.jwk`"   = "`cat $prfx.12.pt`"
 
-test "`jose jwe dec -i $prfx.13.jweg -k $prfx.13.1.jwk`" == "`cat $prfx.13.pt`"
-test "`jose jwe dec -i $prfx.13.jweg -k $prfx.13.2.jwk`" == "`cat $prfx.13.pt`"
-test "`jose jwe dec -i $prfx.13.jweg -k $prfx.13.3.jwk`" == "`cat $prfx.13.pt`"
+test "`jose jwe dec -i $prfx.13.jweg -k $prfx.13.1.jwk`" = "`cat $prfx.13.pt`"
+test "`jose jwe dec -i $prfx.13.jweg -k $prfx.13.2.jwk`" = "`cat $prfx.13.pt`"
+test "`jose jwe dec -i $prfx.13.jweg -k $prfx.13.3.jwk`" = "`cat $prfx.13.pt`"

--- a/tests/jose-jwe-enc
+++ b/tests/jose-jwe-enc
@@ -18,7 +18,7 @@ jqopt() {
     if ! which jq >/dev/null 2>&1; then
         echo "$3"
     else
-        jq -r "if $2 | type | . == \"string\" then $2 else error(\"\") end" < $1
+        jq -r "if $2 | type | . = \"string\" then $2 else error(\"\") end" < $1
     fi
 }
 
@@ -26,52 +26,52 @@ jqbopt() {
     if ! which jq >/dev/null 2>&1; then
         echo "$4"
     else
-        jq -r "if $2 | type | . == \"string\" then $2 else error(\"\") end" < $1 \
+        jq -r "if $2 | type | . = \"string\" then $2 else error(\"\") end" < $1 \
             | jose b64 dec -i- \
-            | jq -r "if $3 | type | . == \"string\" then $3 else error(\"\") end"
+            | jq -r "if $3 | type | . = \"string\" then $3 else error(\"\") end"
     fi
 }
 
 for msg in "hi" "this is a longer message that is more than one block"; do
     for w in $WRAP; do
-        [ $w == "dir" ] && continue
+        [ $w = "dir" ] && continue
 
         jose jwk gen -i "{\"alg\":\"$w\"}" -o $jwk
 
-        echo -n "$msg" | jose jwe enc -I- -k $jwk -o $jwe
-        [ "`jqopt $jwe .header.alg $w`" == "$w" ]
-        [ "`jose jwe dec -i $jwe -k $jwk -O-`" == "$msg" ]
+        printf '%s' "$msg" | jose jwe enc -I- -k $jwk -o $jwe
+        [ "`jqopt $jwe .header.alg $w`" = "$w" ]
+        [ "`jose jwe dec -i $jwe -k $jwk -O-`" = "$msg" ]
 
         for e in $ENCR; do
-            echo -n "$msg" | jose jwe enc \
+            printf '%s' "$msg" | jose jwe enc \
                 -i "{\"protected\":{\"enc\":\"$e\"}}" -I- \
                 -k $jwk -o $jwe
-            [ "`jqopt $jwe .header.alg $w`" == "$w" ]
-            [ "`jqbopt $jwe .protected .enc $e`" == "$e" ]
-            [ "`jose jwe dec -i $jwe -k $jwk -O-`" == "$msg" ]
+            [ "`jqopt $jwe .header.alg $w`" = "$w" ]
+            [ "`jqbopt $jwe .protected .enc $e`" = "$e" ]
+            [ "`jose jwe dec -i $jwe -k $jwk -O-`" = "$msg" ]
         done
     done
 
     for e in $ENCR; do
         jose jwk gen -i "{\"alg\":\"$e\"}" -o $jwk
 
-        echo -n "$msg" | jose jwe enc \
+        printf '%s' "$msg" | jose jwe enc \
             -i "{\"protected\":{\"alg\":\"dir\"}}" -I- \
             -k $jwk -o $jwe
-        [ "`jqbopt $jwe .protected .alg dir`" == "dir" ]
-        [ "`jqbopt $jwe .protected .enc $e`" == "$e" ]
-        [ "`jose jwe dec -i $jwe -k $jwk -O-`" == "$msg" ]
+        [ "`jqbopt $jwe .protected .alg dir`" = "dir" ]
+        [ "`jqbopt $jwe .protected .enc $e`" = "$e" ]
+        [ "`jose jwe dec -i $jwe -k $jwk -O-`" = "$msg" ]
 
-        echo -n "$msg" | jose jwe enc -I- -k $jwk -o $jwe
-        [ "`jqopt $jwe .header.alg dir`" == "dir" ]
-        [ "`jqbopt $jwe .protected .enc $e`" == "$e" ]
-        [ "`jose jwe dec -i $jwe -k $jwk -O-`" == "$msg" ]
+        printf '%s' "$msg" | jose jwe enc -I- -k $jwk -o $jwe
+        [ "`jqopt $jwe .header.alg dir`" = "dir" ]
+        [ "`jqbopt $jwe .protected .enc $e`" = "$e" ]
+        [ "`jose jwe dec -i $jwe -k $jwk -O-`" = "$msg" ]
     done
 
     for tmpl in '{"kty":"oct","bytes":32}' '{"kty":"RSA","bits":2048}' '{"kty":"EC","crv":"P-256"}'; do
         jose jwk gen -i "$tmpl" -o $jwk
 
-        echo -n "$msg" | jose jwe enc -I- -k $jwk -o $jwe
-        [ "`jose jwe dec -i $jwe -k $jwk -O-`" == "$msg" ]
+        printf '%s' "$msg" | jose jwe enc -I- -k $jwk -o $jwe
+        [ "`jose jwe dec -i $jwe -k $jwk -O-`" = "$msg" ]
     done
 done

--- a/tests/jose-jwe-fmt
+++ b/tests/jose-jwe-fmt
@@ -6,15 +6,15 @@ for f in $VECTORS/*.jwec; do
     gen=`echo $f | sed 's|jwec|jweg|'`
 
     if [ -f $flat ]; then
-        [ `jose jwe fmt -i $flat -c` == $cmpct ]
-        [ `jose jwe fmt -i $flat | jose jwe fmt -i- -c` == $cmpct ]
+        [ `jose jwe fmt -i $flat -c` = $cmpct ]
+        [ `jose jwe fmt -i $flat | jose jwe fmt -i- -c` = $cmpct ]
     fi
 
     if [ -f $gen ]; then
-        [ `jose jwe fmt -i $gen -c` == $cmpct ]
-        [ `jose jwe fmt -i $gen | jose jwe fmt -i- -c` == $cmpct ]
+        [ `jose jwe fmt -i $gen -c` = $cmpct ]
+        [ `jose jwe fmt -i $gen | jose jwe fmt -i- -c` = $cmpct ]
     fi
 
-    [ `jose jwe fmt -i $f -c` == $cmpct ]
-    [ `jose jwe fmt -i $f | jose jwe fmt -i- -c` == $cmpct ]
+    [ `jose jwe fmt -i $f -c` = $cmpct ]
+    [ `jose jwe fmt -i $f | jose jwe fmt -i- -c` = $cmpct ]
 done

--- a/tests/jose-jwk-exc
+++ b/tests/jose-jwk-exc
@@ -19,9 +19,9 @@ for T in '{"alg":"ECDH"}' '{"alg":"ECDH","crv":"P-256"}' '{"kty":"EC","crv":"P-2
     b=`jose jwk exc -l $tmpdir/exc_b.jwk -r $tmpdir/exc_a.pub.jwk`
     c=`jose jwk exc -l $tmpdir/exc_a.jwk -r $tmpdir/exc_b.jwk`
     d=`jose jwk exc -l $tmpdir/exc_b.jwk -r $tmpdir/exc_a.jwk`
-    test "$a" == "$b"
-    test "$c" == "$d"
-    test "$a" == "$c"
+    test "$a" = "$b"
+    test "$c" = "$d"
+    test "$a" = "$c"
 
     ! jose jwk exc -l $tmpdir/exc_a.pub.jwk -r $tmpdir/exc_b.jwk
     ! jose jwk exc -l $tmpdir/exc_b.pub.jwk -r $tmpdir/exc_a.jwk

--- a/tests/jose-jwk-pub
+++ b/tests/jose-jwk-pub
@@ -8,8 +8,8 @@ ooct='{"a":"foo","key_ops":[],"kty":"oct"}'
 orsa='{"a":"bar","key_ops":["encrypt"],"kty":"RSA"}'
 oec='{"a":"baz","key_ops":["encrypt"],"kty":"EC"}'
 ojwkset="{\"keys\":[$ooct,$orsa,$oec]}"
-test "`echo $ioct    | jose jwk pub -i-`" == "$ooct"
-test "`echo $irsa    | jose jwk pub -i-`" == "$orsa"
-test "`echo $iec     | jose jwk pub -i-`" == "$oec"
-test "`echo $ijwkset | jose jwk pub -i-`" == "$ojwkset"
-test "`echo $iec     | jose jwk pub -i- -s`" == "{\"keys\":[$oec]}"
+test "`echo $ioct    | jose jwk pub -i-`" = "$ooct"
+test "`echo $irsa    | jose jwk pub -i-`" = "$orsa"
+test "`echo $iec     | jose jwk pub -i-`" = "$oec"
+test "`echo $ijwkset | jose jwk pub -i-`" = "$ojwkset"
+test "`echo $iec     | jose jwk pub -i- -s`" = "{\"keys\":[$oec]}"

--- a/tests/jose-jwk-thp
+++ b/tests/jose-jwk-thp
@@ -2,10 +2,10 @@
 
 a=`jose jwk thp -i $VECTORS/rfc7638_3.1.jwk -a S256`
 b=`cat $VECTORS/rfc7638_3.1.thp`
-[ $a == $b ]
+[ $a = $b ]
 
 jwk=`jose jwk thp -i $VECTORS/rfc7520_4.8.jwkset -f HYRNOxxOOHap0amTONoy1bHnS5M`
-[ "`echo ${jwk} | jose jwk thp -i- -a S1`" == "HYRNOxxOOHap0amTONoy1bHnS5M" ]
+[ "`echo ${jwk} | jose jwk thp -i- -a S1`" = "HYRNOxxOOHap0amTONoy1bHnS5M" ]
 jose fmt -j "$jwk" -O \
     -g kty -q EC    -EUU \
     -g crv -q P-521 -EUU \

--- a/tests/jose-jwk-use
+++ b/tests/jose-jwk-use
@@ -32,11 +32,11 @@ echo "$tmp" | jose jwk use -i- -a -u encrypt -u sign
 jwkset=`jose jwk gen -i '{"keys":[{"alg":"A128KW"},{"alg":"ES256"}]}'`
 
 [ "`echo "$jwkset" | jose jwk use -i- -u wrapKey -s -o-`" \
-    == "`jose fmt -j "$jwkset" -g keys -d 1 -Uo-`" ]
+    = "`jose fmt -j "$jwkset" -g keys -d 1 -Uo-`" ]
 [ "`echo "$jwkset" | jose jwk use -i- -u verify -s -o-`" \
-    == "`jose fmt -j "$jwkset" -g keys -d 0 -Uo-`" ]
+    = "`jose fmt -j "$jwkset" -g keys -d 0 -Uo-`" ]
 [ "`echo "$jwkset" | jose jwk use -i- -u wrapKey -o-`" \
-    == "`jose fmt -j "$jwkset" -g keys -g 0 -o-`" ]
+    = "`jose fmt -j "$jwkset" -g keys -g 0 -o-`" ]
 [ "`echo "$jwkset" | jose jwk use -i- -u verify -o-`" \
-    == "`jose fmt -j "$jwkset" -g keys -g 1 -o-`" ]
+    = "`jose fmt -j "$jwkset" -g keys -g 1 -o-`" ]
 echo "$jwkset" | jose jwk use -i- -u verify -o-

--- a/tests/jose-jws-fmt
+++ b/tests/jose-jws-fmt
@@ -6,15 +6,15 @@ for f in $VECTORS/*.jwsc; do
     gen=`echo $f | sed 's|jwsc|jwsg|'`
 
     if [ -f $flat ]; then
-        [ `jose jws fmt -i $flat -c` == $cmpct ]
-        [ `jose jws fmt -i $flat | jose jws fmt -i- -c` == $cmpct ]
+        [ `jose jws fmt -i $flat -c` = $cmpct ]
+        [ `jose jws fmt -i $flat | jose jws fmt -i- -c` = $cmpct ]
     fi
 
     if [ -f $gen ]; then
-        [ `jose jws fmt -i $gen -c` == $cmpct ]
-        [ `jose jws fmt -i $gen | jose jws fmt -i- -c` == $cmpct ]
+        [ `jose jws fmt -i $gen -c` = $cmpct ]
+        [ `jose jws fmt -i $gen | jose jws fmt -i- -c` = $cmpct ]
     fi
 
-    [ `jose jws fmt -i $f -c` == $cmpct ]
-    [ `jose jws fmt -i $f | jose jws fmt -i- -c` == $cmpct ]
+    [ `jose jws fmt -i $f -c` = $cmpct ]
+    [ `jose jws fmt -i $f | jose jws fmt -i- -c` = $cmpct ]
 done

--- a/tests/jose-jws-sig
+++ b/tests/jose-jws-sig
@@ -11,7 +11,7 @@ onexit() {
 trap onexit EXIT
 
 msg=$tmpdir/msg.txt
-echo -n hi > $msg
+printf "hi" > $msg
 
 for a in $ALGS; do
     jwk=$tmpdir/$a.jwk
@@ -28,8 +28,8 @@ for a in $ALGS; do
     jwk=$tmpdir/$a.jwk
     jws=$tmpdir/$a.jws
 
-    echo -n hi | jose jws sig -I- -k $jwk    | jose jws ver -i- -k $jwk
-    echo -n hi | jose jws sig -I- -k $jwk -c | jose jws ver -i- -k $jwk
+    printf "hi" | jose jws sig -I- -k $jwk    | jose jws ver -i- -k $jwk
+    printf "hi" | jose jws sig -I- -k $jwk -c | jose jws ver -i- -k $jwk
 
     jose jws sig -o $jws -k $jwk -I $msg
     jose jws ver -i $jws -k $jwk
@@ -40,24 +40,24 @@ for a in $ALGS; do
     rm -f $jws
 
     det=`jose jws sig -I $msg -k $jwk -o /dev/null -O-`
-    [ "$det" == "hi" ]
+    [ "$det" = "hi" ]
 
     jws=`jose jws sig -I $msg -k $jwk -O /dev/null`
     ! jose jws ver -i "$jws" -k $jwk
     det=`jose jws ver -i "$jws" -k $jwk -I $msg -O-`
-    [ "$det" == "hi" ]
+    [ "$det" = "hi" ]
 
     jws=`jose jws sig -I $msg -k $jwk`
     det=`jose jws ver -i "$jws" -k $jwk`
-    [ "$det" == "" ]
+    [ "$det" = "" ]
     det=`jose jws ver -i "$jws" -k $jwk -O-`
-    [ "$det" == "hi" ]
+    [ "$det" = "hi" ]
 
     jws=`jose jws sig -I $msg -k $jwk -c`
     det=`jose jws ver -i "$jws" -k $jwk`
-    [ "$det" == "" ]
+    [ "$det" = "" ]
     det=`jose jws ver -i "$jws" -k $jwk -O-`
-    [ "$det" == "hi" ]
+    [ "$det" = "hi" ]
 
     jws=`jose jws sig -k $jwk -I $msg -s "{\"protected\":{\"alg\":\"$a\"}}"`
     jose jws ver -i "$jws" -k $jwk
@@ -66,7 +66,7 @@ for a in $ALGS; do
     jose jws ver -i "$jws" -k $jwk
 
     for b in $ALGS; do
-        [ $a == $b ] && continue
+        [ $a = $b ] && continue
 
         ! jose jws sig -I $msg -k $jwk -s "{\"protected\":{\"alg\":\"$b\"}}"
 
@@ -88,6 +88,6 @@ done
 for tmpl in '{"kty":"oct","bytes":32}' '{"kty":"RSA","bits":2048}' '{"kty":"EC","crv":"P-256"}'; do
     jose jwk gen -i "$tmpl" -o $tmpdir/jwk
 
-    echo -n "$msg" | jose jws sig -I- -k $tmpdir/jwk -o $tmpdir/jws
-    [ "`jose jws ver -i $tmpdir/jws -k $tmpdir/jwk -O-`" == "$msg" ]
+    printf '%s' "$msg" | jose jws sig -I- -k $tmpdir/jwk -o $tmpdir/jws
+    [ "`jose jws ver -i $tmpdir/jws -k $tmpdir/jwk -O-`" = "$msg" ]
 done

--- a/tests/vectors/strip.sh
+++ b/tests/vectors/strip.sh
@@ -2,6 +2,6 @@
 
 while [ $# -gt 0 ]; do
 	tmp=`tr -d ' \n\r' < $1`
-	echo -n "$tmp" > $1
+	printf '%s' "$tmp" > $1
 	shift
 done


### PR DESCRIPTION
The previous commit (9e8c51b) changed the shell in the tests from bash
to sh and performed a few required conversions, however there were still
a few conversions to perform, most notably, using = instead of ==.

Tests were failing in Debian/Ubuntu.