### PR TITLE
ci: add github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,107 @@
+---
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  linux:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        compiler:
+          - gcc
+          - clang
+        os:
+          - fedora:rawhide
+          - fedora:latest
+          - centos:8
+          - debian:testing
+          - debian:latest
+          - ubuntu:devel
+          - ubuntu:rolling
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Show OS information
+        run: |
+          cat /etc/os-release 2>/dev/null || echo /etc/os-release not available
+
+      - name: Install build dependencies
+        run: bash .github/workflows/install-dependencies
+
+      - name: Build jose
+        run: |
+          mkdir -p build && cd build
+          export ninja=$(command -v ninja)
+          [ -z "${ninja}" ] && export ninja=$(command -v ninja-build)
+          meson .. || cat meson-logs/meson-log.txt >&2
+          ${ninja}
+
+      - name: Run tests
+        run: |
+          cd build
+          if ! meson test; then
+            cat meson-logs/testlog.txt >&2
+            exit -1
+          fi
+
+      - name: Show full test logs
+        run: |
+          if [ -r build/meson-logs/testlog.txt ]; then
+            cat build/meson-logs/testlog.txt >&2
+          else
+            echo "No test log available" >&2
+          fi
+
+    container:
+      image: ${{matrix.os}}
+      env:
+        DISTRO: ${{matrix.os}}
+        CC: ${{ matrix.compiler }}
+
+  osx:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        compiler:
+          - gcc
+          - clang
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Show OS information
+        run: |
+          cat /etc/os-release 2>/dev/null || echo /etc/os-release not available
+
+      - name: Install build dependencies
+        run: bash .github/workflows/install-dependencies
+
+      - name: Build jose
+        run: |
+          mkdir -p build && cd build
+          export ninja=$(command -v ninja)
+          [ -z "${ninja}" ] && export ninja=$(command -v ninja-build)
+          CFLAGS=-I$(brew --prefix openssl)/include LDFLAGS=-L$(brew --prefix openssl)/lib PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig meson .. || cat meson-logs/meson-log.txt >&2
+          ${ninja}
+
+      - name: Run tests
+        run: |
+          cd build
+          if ! meson test; then
+            cat meson-logs/testlog.txt >&2
+            exit -1
+          fi
+
+      - name: Show full test logs
+        run: |
+          if [ -r build/meson-logs/testlog.txt ]; then
+            cat build/meson-logs/testlog.txt >&2
+          else
+            echo "No test log available" >&2
+          fi
+
+    env:
+      DISTRO: osx:macos-latest
+      CC: ${{ matrix.compiler }}
+
+# vim:set ts=2 sw=2 et:

--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -1,0 +1,39 @@
+#!/bin/sh -ex
+
+COMMON="meson curl git file bzip2 ${CC}"
+
+case "${DISTRO}" in
+osx:*)
+    brew update
+    for pkg in pkg-config jansson openssl zlib meson; do
+        brew ls --versions "${pkg}" || brew install "${pkg}"
+        brew outdated "${pkg}" || brew upgrade "${pkg}" || true
+    done
+    ;;
+
+debian:*|ubuntu:*)
+    export DEBIAN_FRONTEND=noninteractive
+    apt clean
+    apt update
+    apt -y install build-essential pkg-config libssl-dev zlib1g-dev \
+                   libjansson-dev ${COMMON}
+    ;;
+
+fedora:*)
+    echo 'max_parallel_downloads=10' >> /etc/dnf/dnf.conf
+    dnf -y clean all
+    dnf -y --setopt=deltarpm=0 update
+    dnf -y install ${COMMON} pkgconfig openssl-devel zlib-devel jansson-devel
+    ;;
+
+centos:*)
+    yum -y clean all
+    yum -y --setopt=deltarpm=0 update
+    yum install -y yum-utils epel-release
+    yum config-manager -y --set-enabled PowerTools \
+        || yum config-manager -y --set-enabled powertools || :
+    yum -y install ${COMMON}
+    yum-builddep -y jose
+    ;;
+esac
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![build](https://github.com/latchset/jose/workflows/build/badge.svg)](https://github.com/latchset/jose/actions)
+
 # Welcome to José!
 
 José is a C-language implementation of the Javascript Object Signing and


### PR DESCRIPTION
As travis as showing to be unreliable and slow, let's move the CI to
Github actions.

Note: I am not sure it supports ppc64le for now, so that wil not be
there as of now. Perhaps we can amend it in the future.

Note 2: ubuntu:bionic seems to have some issues with meson, so I left
it out also for now.

We are builing the following platforms for x86_64, with both clang and
gcc:

- fedora:rawhide
- fedora:latest
- centos:8
- debian:testing
- debian:latest
- ubuntu:devel
- ubuntu:rolling
- macos-latest