### PR TITLE
Change default JWK thumbprint algorithm to SHA-256

### DIFF
--- a/cmd/jwk/thp.c
+++ b/cmd/jwk/thp.c
@@ -90,7 +90,7 @@ static const jcmd_cfg_t cfgs[] = {
         .off = offsetof(jcmd_opt_t, hash),
         .set = opt_set_hash,
         .doc = doc_hash,
-        .def = "S1",
+        .def = "S256",
     },
     {
         .opt = { "output", required_argument, .val = 'o' },

--- a/tests/jose-jwk-thp
+++ b/tests/jose-jwk-thp
@@ -4,11 +4,19 @@ a=`jose jwk thp -i $VECTORS/rfc7638_3.1.jwk -a S256`
 b=`cat $VECTORS/rfc7638_3.1.thp`
 [ $a = $b ]
 
-jwk=`jose jwk thp -i $VECTORS/rfc7520_4.8.jwkset -f HYRNOxxOOHap0amTONoy1bHnS5M`
+jwk=`jose jwk thp -i $VECTORS/rfc7520_4.8.jwkset -a S1 -f HYRNOxxOOHap0amTONoy1bHnS5M`
 [ "`echo ${jwk} | jose jwk thp -i- -a S1`" = "HYRNOxxOOHap0amTONoy1bHnS5M" ]
 jose fmt -j "$jwk" -O \
     -g kty -q EC    -EUU \
     -g crv -q P-521 -EUU \
     -g kid -q bilbo.baggins@hobbiton.example -EUU
 
-! jose jwk thp -i $VECTORS/rfc7520_4.8.jwkset -f VHriznG7vJAFpXMXRmGgAkA5sEE
+! jose jwk thp -i $VECTORS/rfc7520_4.8.jwkset -a S1 -f VHriznG7vJAFpXMXRmGgAkA5sEE
+
+# Check default thumbprint algorithm (SHA-256).
+RFC_7638_3_1="${VECTORS}/rfc7638_3.1"
+jwk="${RFC_7638_3_1}.jwk"
+thp256="${RFC_7638_3_1}.thp"
+[ "$(jose jwk thp -i ${jwk})" = "$(jose jwk thp -i ${jwk} -a S256)" ]
+[ "$(jose jwk thp -i ${jwk})" = "$(cat ${thp256})" ]
+


### PR DESCRIPTION
As both clevis and tang have moved to not depend on jose's default JWK thp algorithm, we can safely change the default in jose from SHA-1 to SHA-256.

Resolves: #86 