### PR TITLE
Add jose_logs to handle logs homogeneously

### DIFF
--- a/cmd/alg.c
+++ b/cmd/alg.c
@@ -16,6 +16,7 @@
  */
 
 #include "jose.h"
+#include "jose/jose_log.h"
 #include "../lib/hooks.h"
 #include <string.h>
 
@@ -61,7 +62,7 @@ opt_set_kind(const jcmd_cfg_t *cfg, void *vopt, const char *arg)
 
     if (strcmp(arg, "?") == 0) {
         for (size_t i = 0; kinds[i].name; i++)
-            fprintf(stdout, "%s\n", kinds[i].name);
+            jose_output("%s\n", kinds[i].name);
 
         exit(EXIT_SUCCESS);
     }
@@ -143,7 +144,7 @@ jcmd_alg(int argc, char *argv[])
     qsort(names, sizeof(names) / sizeof(*names), sizeof(*names), cmp);
 
     for (size_t i = 0; i < sizeof(names) / sizeof(*names); i++)
-        fprintf(stdout, "%s\n", names[i]);
+        jose_output("%s\n", names[i]);
 
     return EXIT_SUCCESS;
 }

--- a/cmd/b64/dec.c
+++ b/cmd/b64/dec.c
@@ -16,6 +16,7 @@
  */
 
 #include "b64.h"
+#include "jose/jose_log.h"
 #include <ctype.h>
 #include <string.h>
 #include <unistd.h>
@@ -64,7 +65,7 @@ jcmd_b64_dec(int argc, char *argv[])
         return EXIT_FAILURE;
 
     if (!opt.input) {
-        fprintf(stderr, "Input not specified!\n");
+        jose_logerr("Input not specified!\n");
         return EXIT_FAILURE;
     }
 

--- a/cmd/b64/enc.c
+++ b/cmd/b64/enc.c
@@ -16,6 +16,7 @@
  */
 
 #include "b64.h"
+#include "jose/jose_log.h"
 #include <string.h>
 #include <unistd.h>
 
@@ -63,7 +64,7 @@ jcmd_b64_enc(int argc, char *argv[])
         return EXIT_FAILURE;
 
     if (!opt.input) {
-        fprintf(stderr, "Input not specified!\n");
+        jose_logerr("Input not specified!\n");
         return EXIT_FAILURE;
     }
 

--- a/cmd/jose.c
+++ b/cmd/jose.c
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#include "jose/jose_log.h"
+
 #include <cmd/jose.h>
 
 #include <sys/types.h>
@@ -97,7 +99,7 @@ jcmd_opt_parse(int argc, char *argv[], const jcmd_cfg_t *cfgs, void *vopt,
         if (cfg->def) {
             uint8_t *buf = vopt;
             if (!cfg->set(cfg, &buf[cfg->off], cfg->def)) {
-                fprintf(stderr, "Invalid default value for %s!\n", cfg->opt.name);
+                jose_logerr("Invalid default value for %s!\n", cfg->opt.name);
                 return false;
             }
         }
@@ -134,7 +136,7 @@ jcmd_opt_parse(int argc, char *argv[], const jcmd_cfg_t *cfgs, void *vopt,
                 found = true;
 
                 if (!cfgs[i].set(&cfgs[i], &buf[cfgs[i].off], optarg)) {
-                    fprintf(stderr, "Invalid %s!\n", cfgs[i].opt.name);
+                    jose_logerr("Invalid %s!\n", cfgs[i].opt.name);
                     goto usage;
                 }
 
@@ -145,8 +147,8 @@ jcmd_opt_parse(int argc, char *argv[], const jcmd_cfg_t *cfgs, void *vopt,
         if (!found) {
             switch (c) {
             case 'h': goto usage;
-            case 'v': fprintf(stderr, "José %d\n", JOSE_VERSION); return false;
-            default:  fprintf(stderr, "Unknown option: %c!\n", c); goto usage;
+            case 'v': jose_logerr("José %d\n", JOSE_VERSION); return false;
+            default:  jose_logerr("Unknown option: %c!\n", c); goto usage;
             }
         }
     }
@@ -154,7 +156,7 @@ jcmd_opt_parse(int argc, char *argv[], const jcmd_cfg_t *cfgs, void *vopt,
     return true;
 
 usage:
-    fprintf(stderr, "Usage: %s\n\n", prefix);
+    jose_logerr("Usage: %s\n\n", prefix);
 
     for (size_t i = 0; i < ncfgs; i++) {
         for (size_t j = 0; cfgs[i].doc[j].doc; j++) {
@@ -163,18 +165,18 @@ usage:
             const char *a = cfgs[i].doc[j].arg;
             const char d = a ? '=' : ' ';
             a = a ? a : "";
-            fprintf(stderr, "  -%c %-*s --%s%c%-*s  %s\n",
+            jose_logerr("  -%c %-*s --%s%c%-*s  %s\n",
                     v, maxa, a,
                     n, d, maxl - (int) strlen(n), a,
                     cfgs[i].doc[j].doc);
         }
 
         if (cfgs[i].def) {
-            fprintf(stderr, "%*sDefault: \"%s\"\n",
+            jose_logerr("%*sDefault: \"%s\"\n",
                     maxa + maxl + 11, "", cfgs[i].def);
         }
 
-        fprintf(stderr, "\n");
+        jose_logerr("\n");
     }
 
     return false;
@@ -515,11 +517,11 @@ main(int argc, char *argv[])
 
     qsort(all, sizeof(all) / sizeof(*all), sizeof(*all), cmp);
 
-    fprintf(stderr, "Usage: jose COMMAND [OPTIONS] [ARGUMENTS]\n\n");
-    fprintf(stderr, "Commands:\n");
+    jose_logerr("Usage: jose COMMAND [OPTIONS] [ARGUMENTS]\n\n");
+    jose_logerr("Commands:\n");
     for (size_t i = 0; i < sizeof(all) / sizeof(*all); i++) {
         if (!(last && strcmp(all[i]->names[0], last) == 0))
-            fprintf(stderr, "\n");
+            jose_logerr("\n");
 
         strcpy(full, "jose");
         for (size_t j = 0; all[i]->names[j]; j++) {
@@ -528,10 +530,10 @@ main(int argc, char *argv[])
                      " %s", all[i]->names[j]);
         }
 
-        fprintf(stderr, "  %-13s %s\n", full, all[i]->desc);
+        jose_logerr("  %-13s %s\n", full, all[i]->desc);
         last = all[i]->names[0];
     }
 
-    fprintf(stderr, "\n");
+    jose_logerr("\n");
     return EXIT_FAILURE;
 }

--- a/cmd/jwe/dec.c
+++ b/cmd/jwe/dec.c
@@ -17,6 +17,7 @@
 
 #include "jwe.h"
 #include "pwd.h"
+#include "jose/jose_log.h"
 #include <unistd.h>
 #include <string.h>
 
@@ -142,18 +143,18 @@ jcmd_jwe_dec(int argc, char *argv[])
         return EXIT_FAILURE;
 
     if (!opt.io.obj) {
-        fprintf(stderr, "Invalid JWE!\n");
+        jose_logerr("Invalid JWE!\n");
         return EXIT_FAILURE;
     }
 
     if (json_array_size(opt.keys) == 0 && !opt.pwd) {
-        fprintf(stderr, "MUST specify a JWK in non-interactive mode!\n\n");
+        jose_logerr("MUST specify a JWK in non-interactive mode!\n\n");
         return EXIT_FAILURE;
     }
 
     cek = unwrap(opt.io.obj, opt.keys, opt.pwd);
     if (!cek) {
-        fprintf(stderr, "Unwrapping failed!\n");
+        jose_logerr("Unwrapping failed!\n");
         return EXIT_FAILURE;
     }
 
@@ -205,7 +206,7 @@ jcmd_jwe_dec(int argc, char *argv[])
     if (opt.io.input) {
         if (json_object_set_new(opt.io.obj, "tag",
                                 jcmd_compact_field(opt.io.input)) < 0) {
-            fprintf(stderr, "Error reading last compact field!\n");
+            jose_logerr("Error reading last compact field!\n");
             return EXIT_FAILURE;
         }
     }

--- a/cmd/jwe/enc.c
+++ b/cmd/jwe/enc.c
@@ -17,6 +17,7 @@
 
 #include "jwe.h"
 #include "pwd.h"
+#include "jose/jose_log.h"
 #include <string.h>
 #include <unistd.h>
 
@@ -45,7 +46,7 @@ prompt(void)
             continue;
 
         if (strlen(p) < 8) {
-            fprintf(stderr, "Password too short!\n");
+            jose_logerr("Password too short!\n");
             continue;
         }
 
@@ -147,15 +148,15 @@ opt_validate(jcmd_opt_t *opt)
     size_t nkeys = json_array_size(opt->keys);
 
     if (nkeys == 0) {
-        fprintf(stderr, "Must specify a JWK or password!\n");
+        jose_logerr("Must specify a JWK or password!\n");
         return false;
     } else if (nkeys > 1 && opt->io.compact) {
-        fprintf(stderr, "Requested compact format with >1 recipient!\n");
+        jose_logerr("Requested compact format with >1 recipient!\n");
         return false;
     }
 
     if (!opt->io.detached) {
-        fprintf(stderr, "Must specify detached input!\n");
+        jose_logerr("Must specify detached input!\n");
         return false;
     }
 
@@ -163,7 +164,7 @@ opt_validate(jcmd_opt_t *opt)
         return false;
 
     if (json_array_size(opt->keys) < json_array_size(opt->rcps)) {
-        fprintf(stderr, "Specified more recipients than keys!\n");
+        jose_logerr("Specified more recipients than keys!\n");
         return false;
     }
 
@@ -190,7 +191,7 @@ wrap(jcmd_opt_t *opt)
         }
 
         if (!jose_jwe_enc_jwk(NULL, opt->io.obj, rcp, jwk, cek)) {
-            fprintf(stderr, "Wrapping failed!\n");
+            jose_logerr("Wrapping failed!\n");
             return NULL;
         }
     }
@@ -310,7 +311,7 @@ jcmd_jwe_enc(int argc, char *argv[])
     if (opt.io.input) {
         if (json_object_set_new(opt.io.obj, "tag",
                                 jcmd_compact_field(opt.io.input)) < 0) {
-            fprintf(stderr, "Error reading last compact field!\n");
+            jose_logerr("Error reading last compact field!\n");
             return EXIT_FAILURE;
         }
     }
@@ -322,7 +323,7 @@ jcmd_jwe_enc(int argc, char *argv[])
         const char *v = NULL;
 
         if (json_unpack(opt.io.obj, "{s:s}", "tag", &v) < 0) {
-            fprintf(stderr, "Missing tag parameter!\n");
+            jose_logerr("Missing tag parameter!\n");
             return false;
         }
 

--- a/cmd/jwk/eql.c
+++ b/cmd/jwk/eql.c
@@ -16,6 +16,7 @@
  */
 
 #include "jwk.h"
+#include "jose/jose_log.h"
 #include <string.h>
 
 #define SUMMARY "Determines if two or more JWKs are equal"
@@ -52,7 +53,7 @@ jcmd_jwk_eql(int argc, char *argv[])
         return EXIT_FAILURE;
 
     if (json_array_size(opt.keys) < 2) {
-        fprintf(stderr, "Must specify at least two JWKs!\n");
+        jose_logerr("Must specify at least two JWKs!\n");
         return EXIT_FAILURE;
     }
 

--- a/cmd/jwk/exc.c
+++ b/cmd/jwk/exc.c
@@ -16,6 +16,7 @@
  */
 
 #include "jwk.h"
+#include "jose/jose_log.h"
 #include <string.h>
 #include <unistd.h>
 
@@ -109,19 +110,19 @@ jcmd_jwk_exc(int argc, char *argv[])
         return EXIT_FAILURE;
 
     if (json_array_size(opt.lcl) != 1) {
-        fprintf(stderr, "Local JWK must be specified exactly once!\n");
+        jose_logerr("Local JWK must be specified exactly once!\n");
         return EXIT_FAILURE;
     }
 
     if (json_array_size(opt.rem) != 1) {
-        fprintf(stderr, "Remote JWK must be specified exactly once!\n");
+        jose_logerr("Remote JWK must be specified exactly once!\n");
         return EXIT_FAILURE;
     }
 
     key = jose_jwk_exc(NULL, json_array_get(opt.lcl, 0),
                        json_array_get(opt.rem, 0));
     if (!key) {
-        fprintf(stderr, "Error performing exchange!\n");
+        jose_logerr("Error performing exchange!\n");
         return EXIT_FAILURE;
     }
 
@@ -131,7 +132,7 @@ jcmd_jwk_exc(int argc, char *argv[])
         return EXIT_FAILURE;
 
     if (json_dumpf(tmpl, opt.output, JSON_COMPACT | JSON_SORT_KEYS) < 0) {
-        fprintf(stderr, "Error writing JWK!\n");
+        jose_logerr("Error writing JWK!\n");
         return EXIT_FAILURE;
     }
 

--- a/cmd/jwk/gen.c
+++ b/cmd/jwk/gen.c
@@ -16,6 +16,7 @@
  */
 
 #include "jwk.h"
+#include "jose/jose_log.h"
 #include <unistd.h>
 
 #define SUMMARY "Creates a random JWK for each input JWK template"
@@ -75,13 +76,13 @@ jcmd_jwk_gen(int argc, char *argv[])
         return EXIT_FAILURE;
 
     if (json_array_size(opt.keys) == 0) {
-        fprintf(stderr, "At least one JWK template is required!\n");
+        jose_logerr("At least one JWK template is required!\n");
         return EXIT_FAILURE;
     }
 
     for (size_t i = 0; i < json_array_size(opt.keys); i++) {
         if (!jose_jwk_gen(NULL, json_array_get(opt.keys, i))) {
-            fprintf(stderr, "JWK generation failed!\n");
+            jose_logerr("JWK generation failed!\n");
             return EXIT_FAILURE;
         }
     }
@@ -89,7 +90,7 @@ jcmd_jwk_gen(int argc, char *argv[])
     if (json_array_size(opt.keys) == 1 && !opt.set) {
         if (json_dumpf(json_array_get(opt.keys, 0), opt.output,
                        JSON_COMPACT | JSON_SORT_KEYS) < 0) {
-            fprintf(stderr, "Error dumping JWK!\n");
+            jose_logerr("Error dumping JWK!\n");
             return EXIT_FAILURE;
         }
     } else {
@@ -100,7 +101,7 @@ jcmd_jwk_gen(int argc, char *argv[])
             return EXIT_FAILURE;
 
         if (json_dumpf(jwks, opt.output, JSON_COMPACT | JSON_SORT_KEYS) < 0) {
-            fprintf(stderr, "Error dumping JWKSet!\n");
+            jose_logerr("Error dumping JWKSet!\n");
             return EXIT_FAILURE;
         }
     }

--- a/cmd/jwk/pub.c
+++ b/cmd/jwk/pub.c
@@ -16,6 +16,7 @@
  */
 
 #include "jwk.h"
+#include "jose/jose_log.h"
 #include <unistd.h>
 
 #define SUMMARY "Cleans private keys from a JWK"
@@ -72,13 +73,13 @@ jcmd_jwk_pub(int argc, char *argv[])
     for (size_t i = 0; !fail && i < json_array_size(opt.keys); i++)
         fail |= !jose_jwk_pub(NULL, json_array_get(opt.keys, i));
     if (fail) {
-        fprintf(stderr, "Error removing private keys!\n");
+        jose_logerr("Error removing private keys!\n");
         return EXIT_FAILURE;
     }
 
     switch (json_array_size(opt.keys)) {
     case 0:
-        fprintf(stderr, "MUST specify at least one JWK(Set)!\n");
+        jose_logerr("MUST specify at least one JWK(Set)!\n");
         return EXIT_FAILURE;
 
     case 1:
@@ -94,7 +95,7 @@ jcmd_jwk_pub(int argc, char *argv[])
     }
 
     if (json_dumpf(out, opt.output, JSON_SORT_KEYS | JSON_COMPACT) < 0) {
-        fprintf(stderr, "Error dumping JWK(Set)!\n");
+        jose_logerr("Error dumping JWK(Set)!\n");
         return EXIT_FAILURE;
     }
 

--- a/cmd/jwk/thp.c
+++ b/cmd/jwk/thp.c
@@ -17,6 +17,7 @@
 
 #include "jwk.h"
 #include "../../lib/hooks.h"
+#include "jose/jose_log.h"
 #include <string.h>
 #include <unistd.h>
 
@@ -48,7 +49,7 @@ opt_set_hash(const jcmd_cfg_t *cfg, void *vopt, const char *arg)
     if (strcmp(arg, "?") == 0) {
         for (const jose_hook_alg_t *a = jose_hook_alg_list(); a; a = a->next) {
             if (a->kind == JOSE_HOOK_ALG_KIND_HASH)
-                fprintf(stdout, "%s\n", a->name);
+                jose_logerr("%s\n", a->name);
         }
 
         exit(EXIT_SUCCESS);
@@ -126,13 +127,13 @@ jcmd_jwk_thp(int argc, char *argv[])
         return EXIT_FAILURE;
 
     if (json_array_size(opt.keys) == 0) {
-        fprintf(stderr, "Must specify JWK(Set)!\n");
+        jose_logerr("Must specify JWK(Set)!\n");
         return EXIT_FAILURE;
     }
 
     dlen = jose_jwk_thp_buf(NULL, NULL, opt.hash, NULL, 0);
     if (dlen == SIZE_MAX) {
-        fprintf(stderr, "Error determining hash size!\n");
+        jose_logerr("Error determining hash size!\n");
         return EXIT_FAILURE;
     }
 
@@ -154,7 +155,7 @@ jcmd_jwk_thp(int argc, char *argv[])
                 continue;
 
             if (!jose_jwk_thp_buf(NULL, jwk, opt.hash, dec, sizeof(dec))) {
-                fprintf(stderr, "Error making thumbprint!\n");
+                jose_logerr("Error making thumbprint!\n");
                 return EXIT_FAILURE;
             }
 

--- a/cmd/jwk/use.c
+++ b/cmd/jwk/use.c
@@ -16,6 +16,7 @@
  */
 
 #include "jwk.h"
+#include "jose/jose_log.h"
 #include <string.h>
 #include <unistd.h>
 
@@ -130,12 +131,12 @@ jcmd_jwk_use(int argc, char *argv[])
         return EXIT_FAILURE;
 
     if (json_array_size(opt.uses) == 0) {
-        fprintf(stderr, "No uses specified!\n");
+        jose_logerr("No uses specified!\n");
         return EXIT_FAILURE;
     }
 
     if (json_array_size(opt.keys) == 0) {
-        fprintf(stderr, "No JWK specified!\n");
+        jose_logerr("No JWK specified!\n");
         return EXIT_FAILURE;
     }
 

--- a/cmd/jws/fmt.c
+++ b/cmd/jws/fmt.c
@@ -16,6 +16,7 @@
  */
 
 #include "jws.h"
+#include "jose/jose_log.h"
 #include <string.h>
 #include <unistd.h>
 
@@ -78,10 +79,9 @@ jcmd_jws_fmt(int argc, char *argv[])
 
         if (json_unpack(opt.obj, "{s:[{s?s}!]}", f->mult, k, &v) < 0 &&
             json_unpack(opt.obj, "{s?s}", k, &v) < 0) {
-            fprintf(stderr, "Input JWS cannot be converted to compact.\n");
+            jose_logerr("Input JWS cannot be converted to compact.\n");
             return EXIT_FAILURE;
         }
-
         fprintf(opt.output, "%s.", v ? v : "");
     } else {
         fprintf(opt.output, "{");
@@ -121,7 +121,7 @@ jcmd_jws_fmt(int argc, char *argv[])
     if (opt.input) {
         if (json_object_set_new(opt.obj, "signature",
                                 jcmd_compact_field(opt.input)) < 0) {
-            fprintf(stderr, "Error reading last compact field!\n");
+            jose_logerr("Error reading last compact field!\n");
             return EXIT_FAILURE;
         }
     }
@@ -132,7 +132,7 @@ jcmd_jws_fmt(int argc, char *argv[])
         if (json_unpack(opt.obj, "{s:s}", "signature", &v) < 0 &&
             json_unpack(opt.obj, "{s:[{s:s}!]}",
                         "signatures", "signature", &v) < 0) {
-            fprintf(stderr, "Missing signature parameter!\n");
+            jose_logerr("Missing signature parameter!\n");
             return EXIT_FAILURE;
         }
 

--- a/cmd/jws/sig.c
+++ b/cmd/jws/sig.c
@@ -16,6 +16,7 @@
  */
 
 #include "jws.h"
+#include "jose/jose_log.h"
 #include <string.h>
 #include <unistd.h>
 
@@ -111,12 +112,12 @@ validate_input(jcmd_opt_t *opt)
         return false;
 
     if (json_array_size(opt->keys) == 0) {
-        fprintf(stderr, "At least one JWK is required to sign!\n");
+        jose_logerr("At least one JWK is required to sign!\n");
         return false;
     }
 
     if (json_array_size(opt->keys) < json_array_size(opt->sigs)) {
-        fprintf(stderr, "Specified more signature templates than JWKs!\n");
+        jose_logerr("Specified more signature templates than JWKs!\n");
         return false;
     }
 
@@ -130,12 +131,12 @@ validate_input(jcmd_opt_t *opt)
         nsigs += 1;
 
     if (opt->io.compact && nsigs > 1) {
-        fprintf(stderr, "Too many signatures for compact serialization!\n");
+        jose_logerr("Too many signatures for compact serialization!\n");
         return false;
     }
 
     if (json_array_size(opt->keys) < json_array_size(opt->sigs)) {
-        fprintf(stderr, "Specified more signatures than keys!\n");
+        jose_logerr("Specified more signatures than keys!\n");
         return false;
     }
 
@@ -210,7 +211,7 @@ jcmd_jws_sig(int argc, char *argv[])
     if (opt.io.input) {
         if (json_object_set_new(opt.io.obj, "signature",
                                 jcmd_compact_field(opt.io.input)) < 0) {
-            fprintf(stderr, "Error reading last compact field!\n");
+            jose_logerr("Error reading last compact field!\n");
             return EXIT_FAILURE;
         }
     }
@@ -222,7 +223,7 @@ jcmd_jws_sig(int argc, char *argv[])
         const char *v = NULL;
 
         if (json_unpack(opt.io.obj, "{s:s}", "signature", &v) < 0) {
-            fprintf(stderr, "Missing signature parameter!\n");
+            jose_logerr("Missing signature parameter!\n");
             return EXIT_FAILURE;
         }
 

--- a/cmd/jws/ver.c
+++ b/cmd/jws/ver.c
@@ -16,6 +16,7 @@
  */
 
 #include "jws.h"
+#include "jose/jose_log.h"
 #include <string.h>
 #include <unistd.h>
 
@@ -87,12 +88,12 @@ static bool
 validate_input(const jcmd_opt_t *opt, json_t **sigs)
 {
     if (json_array_size(opt->keys) == 0) {
-        fprintf(stderr, "MUST specify a JWK(Set)!\n");
+        jose_logerr("MUST specify a JWK(Set)!\n");
         return false;
     }
 
     if (!opt->io.obj) {
-        fprintf(stderr, "Invalid JWS!\n");
+        jose_logerr("Invalid JWS!\n");
         return false;
     }
 
@@ -100,7 +101,7 @@ validate_input(const jcmd_opt_t *opt, json_t **sigs)
     if (!*sigs)
         *sigs = json_pack("[O]", opt->io.obj);
     if (!json_is_array(*sigs)) {
-        fprintf(stderr, "Signatures value must be an array!\n");
+        jose_logerr("Signatures value must be an array!\n");
         return false;
     }
 
@@ -123,7 +124,7 @@ jcmd_jws_ver(int argc, char *argv[])
     io = jose_jws_ver_io(NULL, opt.io.obj, NULL, opt.keys, opt.all);
     io = jcmd_jws_prep_io(&opt.io, io);
     if (!io) {
-        fprintf(stderr, "Error initializing signature context!\n");
+        jose_logerr("Error initializing signature context!\n");
         return EXIT_FAILURE;
     }
 
@@ -156,13 +157,13 @@ jcmd_jws_ver(int argc, char *argv[])
     if (opt.io.input) {
         if (json_object_set_new(opt.io.obj, "signature",
                                 jcmd_compact_field(opt.io.input)) < 0) {
-            fprintf(stderr, "Error reading last compact field!\n");
+            jose_logerr("Error reading last compact field!\n");
             return EXIT_FAILURE;
         }
     }
 
     if (!io->done(io)) {
-        fprintf(stderr, "Signature validation failed!\n");
+        jose_logerr("Signature validation failed!\n");
         return EXIT_FAILURE;
     }
 

--- a/jose/jose_log.h
+++ b/jose/jose_log.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __JOSE_LOG__
+#define __JOSE_LOG__
+
+#ifdef __PRINTF_ERR__
+#define jose_logerr(...) printf (__VA_ARGS__)
+#elsif
+#ifdef __SYSLOG__
+#define jose_logerr(...) // TODO: dump log to syslog
+#endif
+#else
+#define jose_logerr(...) fprintf(stderr, __VA_ARGS__)
+#endif
+
+#ifdef __SYSLOG__
+#define jose_output(...) // TODO: dump log to syslog
+#else
+#define jose_output(...) fprintf(stdout, __VA_ARGS__)
+#endif
+
+
+#endif // __JOSE_LOG__


### PR DESCRIPTION
This change fixes #99. It provides a very simple wrapper for
logging that could be used in order to change logs quickly to
other log infrastructure (still to be defined)