### PR TITLE
man: add option to skip building man pages

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -37,7 +37,6 @@ zlib = dependency('zlib')
 threads = dependency('threads')
 jansson = dependency('jansson', version: '>=2.10')
 libcrypto = dependency('libcrypto', version: '>=1.0.2')
-a2x = find_program('a2x', required: false)
 
 mans = []
 
@@ -63,14 +62,17 @@ pkg.generate(
   requires: 'jansson',
 )
 
-if a2x.found()
-  foreach m : mans
-    custom_target(m.split('/')[-1], input: m + '.adoc', output: m.split('/')[-1],
-      command: [a2x, '-f', 'manpage', '-D', meson.current_build_dir(), '@INPUT@'],
-      install_dir: join_paths(get_option('mandir'), 'man' + m.split('.')[-1]),
-      install: true
-    )
-  endforeach
-else
-  warning('Will not build man pages due to missing dependencies!')
+if not get_option('skip_manpages')
+  a2x = find_program('a2x', required: false)
+  if a2x.found()
+    foreach m : mans
+      custom_target(m.split('/')[-1], input: m + '.adoc', output: m.split('/')[-1],
+        command: [a2x, '-f', 'manpage', '-D', meson.current_build_dir(), '@INPUT@'],
+        install_dir: join_paths(get_option('mandir'), 'man' + m.split('.')[-1]),
+        install: true
+      )
+    endforeach
+  else
+    warning('Will not build man pages due to missing dependencies!')
+  endif
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('skip_manpages', type: 'boolean', value: false, description: 'Do not build manpages')


### PR DESCRIPTION
Add a 'skip_manpages' option to meson, so that man pages do not get built.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---

While building the package for openwrt, I am encountering problems with a2x when building the man pages.  Openwrt does not use the man pages, so we can just skip it altogether.  Although it may be worth to understand why a2x is failing, the option to skip the man pages seems to be useful by itself.

This was tested with native builds, with and without the manpages, on gentoo, x86_64; and also cross-building for openwrt master, mediatek/aarch64-cortexa53 without manpages.