### PR TITLE
meson: add option to disable building manpages

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,8 @@ project('jose', 'c', license: 'APL2',
     'prefix=/usr',
     'warning_level=2',
     'werror=true'
-  ]
+  ],
+  meson_version: '>=0.47.0',
 )
 
 licensedir = join_paths(get_option('prefix'), 'share', 'licenses', meson.project_name())
@@ -37,7 +38,7 @@ zlib = dependency('zlib')
 threads = dependency('threads')
 jansson = dependency('jansson', version: '>=2.10')
 libcrypto = dependency('libcrypto', version: '>=1.0.2')
-a2x = find_program('a2x', required: false)
+a2x = find_program('a2x', required: get_option('docs'))
 
 mans = []
 
@@ -71,6 +72,6 @@ if a2x.found()
       install: true
     )
   endforeach
-else
+elif get_option('docs').auto()
   warning('Will not build man pages due to missing dependencies!')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('docs', type: 'feature', description: 'Whether to build asciidoc manpages')


### PR DESCRIPTION
Instead of always building man pages if asciidoc is installed, use a feature option to allow making its absence an error, or to avoid building it even if installed.