### PR TITLE
Update CI (#8)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
           - clang
         os:
           - fedora:latest
+          - quay.io/centos/centos:stream9
           - quay.io/centos/centos:stream8
           - debian:testing
           - debian:latest
@@ -23,23 +24,20 @@ jobs:
         stable:: [true]
         include:
           - compiler: gcc
-            os: quay.io/centos/centos:stream9
-            stable: true
+            os: fedora:rawhide
+            stable: false
+          - compiler: clang
+            os: fedora:rawhide
+            stable: false
+          - compiler: gcc
+            os: ubuntu:devel
+            stable: false
+          - compiler: clang
+            os: ubuntu:devel
+            stable: false
           - compiler: gcc
             os: centos:7
             stable: true
-          - compiler: gcc
-            os: fedora:rawhide
-            stable: false
-          - compiler: clang
-            os: fedora:rawhide
-            stable: false
-          - compiler: gcc
-            os: ubuntu:devel
-            stable: false
-          - compiler: clang
-            os: ubuntu:devel
-            stable: false
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
             stable: false
     steps:
       - uses: actions/checkout@v3
-      
+
       - name: Show OS information
         run: |
           cat /etc/os-release 2>/dev/null || echo /etc/os-release not available

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 
 jobs:
   linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     continue-on-error: ${{ ! matrix.stable }}
     strategy:
       matrix:
@@ -15,12 +15,19 @@ jobs:
         os:
           - fedora:latest
           - quay.io/centos/centos:stream8
-          - quay.io/centos/centos:stream9
           - debian:testing
           - debian:latest
           - ubuntu:rolling
+          - ubuntu:jammy
+          - ubuntu:focal
         stable:: [true]
         include:
+          - compiler: gcc
+            os: quay.io/centos/centos:stream9
+            stable: true
+          - compiler: gcc
+            os: centos:7
+            stable: true
           - compiler: gcc
             os: fedora:rawhide
             stable: false
@@ -34,8 +41,8 @@ jobs:
             os: ubuntu:devel
             stable: false
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v3
+      
       - name: Show OS information
         run: |
           cat /etc/os-release 2>/dev/null || echo /etc/os-release not available

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           mkdir -p build && cd build
           export ninja=$(command -v ninja)
           [ -z "${ninja}" ] && export ninja=$(command -v ninja-build)
-          meson .. || cat meson-logs/meson-log.txt >&2
+          meson setup .. || cat meson-logs/meson-log.txt >&2
           ${ninja}
 
       - name: Run tests
@@ -100,7 +100,7 @@ jobs:
           mkdir -p build && cd build
           export ninja=$(command -v ninja)
           [ -z "${ninja}" ] && export ninja=$(command -v ninja-build)
-          CFLAGS=-I$(brew --prefix openssl)/include LDFLAGS=-L$(brew --prefix openssl)/lib PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig meson .. || cat meson-logs/meson-log.txt >&2
+          CFLAGS=-I$(brew --prefix openssl)/include LDFLAGS=-L$(brew --prefix openssl)/lib PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig meson setup .. || cat meson-logs/meson-log.txt >&2
           ${ninja}
 
       - name: Run tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
           - gcc
           - clang
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Show OS information
         run: |

--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -30,25 +30,22 @@ fedora:*)
     dnf -y install ${COMMON} pkgconfig openssl-devel zlib-devel jansson-devel
     ;;
 
-*centos:*)
+centos:7)
     yum -y clean all
     yum -y --setopt=deltarpm=0 update
-    yum install -y yum-utils epel-release
-    yum-config-manager -y --enable crb \
-        || yum-config-manager -y --enable powertools || :
+    yum install -y yum-utils epel-release centos-release-scl llvm-toolset-7
     yum -y install ${COMMON}
     yum-builddep -y jose
     ;;
 
 *centos:stream*)
     dnf -y clean all
-    dnf -y --setopt=deltarpm=0 update
-    dnf install -y dnf-plugins-core epel-release
-    dnf config-manager -y --set-enabled powertools \
-        || dnf config-manager -y --set-enabled crb || :
-    dnf -y install --allowerasing ${COMMON}
+    dnf -y --allowerasing --setopt=deltarpm=0 update
+    dnf install -y yum-utils epel-release
+    dnf config-manager -y --set-enabled crb \
+        || dnf config-manager -y --set-enabled powertools || :
+    dnf -y --allowerasing install ${COMMON}
     dnf builddep -y jose
     ;;
-
 esac
 # vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:

--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -34,10 +34,21 @@ fedora:*)
     yum -y clean all
     yum -y --setopt=deltarpm=0 update
     yum install -y yum-utils epel-release
-    yum config-manager -y --set-enabled crb \
-        || yum config-manager -y --set-enabled powertools || :
-    yum -y --allowerasing install ${COMMON}
+    yum-config-manager -y --enable crb \
+        || yum-config-manager -y --enable powertools || :
+    yum -y install ${COMMON}
     yum-builddep -y jose
     ;;
+
+*centos:stream*)
+    dnf -y clean all
+    dnf -y --setopt=deltarpm=0 update
+    dnf install -y dnf-plugins-core epel-release
+    dnf config-manager -y --set-enabled powertools \
+        || dnf config-manager -y --set-enabled crb || :
+    dnf -y install --allowerasing ${COMMON}
+    dnf builddep -y jose
+    ;;
+
 esac
 # vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:

--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-COMMON="meson curl git file bzip2 ${CC}"
+COMMON="meson curl git file bzip2 asciidoc jq ${CC}"
 
 case "${DISTRO}" in
 osx:*)

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Decryption failed!
 Building Jose is fairly straightforward:
 
     $ mkdir build && cd build
-    $ meson .. --prefix=/usr
+    $ meson setup .. --prefix=/usr
     $ ninja
     $ sudo ninja install
 
@@ -123,9 +123,9 @@ You can even run the tests if you'd like:
 To build a FreeBSD, HardenedBSD or OPNsense package
 use:
 
-    (as root) # pkg install meson pkgconf jansson openssl
+    (as root) # pkg install meson pkgconf jansson openssl jq
     $ mkdir build && cd build
-    $ meson .. --prefix=/usr/local
+    $ meson setup .. --prefix=/usr/local
     $ ninja
     $ meson test
     (as root) # ninja install


### PR DESCRIPTION
This updates github actions to:

Include current OS versions
Update actions/checkout to version 3 in advance of the imminent NodeJS deprecation
Add dependency installation for CentOS Stream versions
In my initial pass, there were failures for Ubuntu:bionic and, for clang on CentOS 7 and CentOS Stream 9. Rather than spend a lot of time trying to resolve the failures I simply removed the clang attempts for CentOS7 and Stream 9. It's probably some dependency issue if someone wants to chase it. I simply removed Ubuntu:bionic since it's EOL at the end of the month anyway.