### PR TITLE
Display pkg_config in test logs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
           else
             echo "No test log available" >&2
           fi
-          cat meson-private/jose.pc
+          cat build/meson-private/jose.pc
 
     container:
       image: ${{matrix.os}}
@@ -114,7 +114,7 @@ jobs:
           else
             echo "No test log available" >&2
           fi
-          cat meson-private/jose.pc
+          cat build/meson-private/jose.pc
 
     env:
       DISTRO: osx:macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
           else
             echo "No test log available" >&2
           fi
+          cat meson-private/jose.pc
 
     container:
       image: ${{matrix.os}}
@@ -113,6 +114,7 @@ jobs:
           else
             echo "No test log available" >&2
           fi
+          cat meson-private/jose.pc
 
     env:
       DISTRO: osx:macos-latest


### PR DESCRIPTION
I don't know if this will help anyone else.  During all the pkg_config changes for PR #98 it was difficult to tell what effects changes where having. There doesn't seem to be a good way to "test" pkg_config as part of github actions (I think you'd have to install and then try and install something like tang on top of it.) But this tiny patch at least displays what pkg_config looks like so it's relatively easy to at least see what changed.