### PR TITLE
Meson changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           mkdir -p build && cd build
           export ninja=$(command -v ninja)
           [ -z "${ninja}" ] && export ninja=$(command -v ninja-build)
-          meson .. || cat meson-logs/meson-log.txt >&2
+          meson setup .. || cat meson-logs/meson-log.txt >&2
           ${ninja}
 
       - name: Run tests
@@ -95,7 +95,7 @@ jobs:
           mkdir -p build && cd build
           export ninja=$(command -v ninja)
           [ -z "${ninja}" ] && export ninja=$(command -v ninja-build)
-          CFLAGS=-I$(brew --prefix openssl)/include LDFLAGS=-L$(brew --prefix openssl)/lib PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig meson .. || cat meson-logs/meson-log.txt >&2
+          CFLAGS=-I$(brew --prefix openssl)/include LDFLAGS=-L$(brew --prefix openssl)/lib PKG_CONFIG_PATH=$(brew --prefix openssl)/lib/pkgconfig meson setup .. || cat meson-logs/meson-log.txt >&2
           ${ninja}
 
       - name: Run tests

--- a/meson.build
+++ b/meson.build
@@ -62,7 +62,7 @@ pkg.generate(
 
   requires_private: [ 'zlib', 'libcrypto' ],
   libraries: libjose_lib,
-  requires: 'jansson',
+  requires: jansson,
 )
 
 if a2x.found()


### PR DESCRIPTION
Two small changes to improve how meson works
- Add "setup" to meson build to eliminate some meson warnings
- Use the library object jansson instead of the string in the pkg_config configuration.  This results in pkg_config actually knowing that there was a minimum version specified.