### PR TITLE
Alternative fix for fedora:rawide

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
         stable:: [true]
         include:
           - compiler: gcc
-            os: fedora:rawhide
+            os: quay.io/fedora/fedora:rawhide
             stable: false
           - compiler: clang
-            os: fedora:rawhide
+            os: quay.io/fedora/fedora:rawhide
             stable: false
           - compiler: gcc
             os: ubuntu:devel

--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -23,7 +23,7 @@ debian:*|ubuntu:*)
     done
     ;;
 
-fedora:*)
+*fedora:*)
     echo 'max_parallel_downloads=10' >> /etc/dnf/dnf.conf
     dnf -y clean all
     dnf -y --setopt=deltarpm=0 update


### PR DESCRIPTION
If I'm reading https://pagure.io/fedora-infrastructure/issue/11358 correctly there's hope that the docker build of Fedora Rawhide will be fixed in a couple of days.  Also if I'm reading that correctly, it seems like the docker build (which I'm assuming github CI uses) is not updated as frequently as you'd hope for a distribution that changes daily.  This change to quay.io for the rawhide builds seems to work for me and is an alternative to PR #133 that gets things working for the moment, and perhaps is a worthwhile longer term solution.