### PR TITLE
lib/openssl/rsaes.c: Fix issue where `jose_hook_alg_find` fails to find the …

### DIFF
--- a/lib/openssl/rsaes.c
+++ b/lib/openssl/rsaes.c
@@ -25,7 +25,7 @@
 
 #include <string.h>
 
-#ifdef EVP_PKEY_CTX_set_rsa_oaep_md
+#if defined (EVP_PKEY_CTX_set_rsa_oaep_md) || (OPENSSL_VERSION_NUMBER >= 0x30000000L)
 #define NAMES "RSA1_5", "RSA-OAEP", "RSA-OAEP-224", "RSA-OAEP-256", "RSA-OAEP-384", "RSA-OAEP-512"
 #define HAVE_OAEP
 #else


### PR DESCRIPTION
…existance of RSA_OAEP algorithm

After upgrading to  openssl 3.x, decryption of cipher started failing
with error `decryption algorithm not found, could not decode key`.

After investigation it was found that before openssl 3.x,
EVP_PKEY_CTX_set_rsa_oaep_md used to be a MACRO but with
openssl 3.x, it became a function.

To fix this, modify the check for MACRO to make it work with
openssl version 3.x or higher.

'''
Without this patch, algorithms listed by `jose_hook_alg_find`
function:
PS512, PS384, PS256, RS512, RS384, RS256, HS512, HS384, HS256,
S1, S224, S256, S384, S512, ES512, ES384, ES256, ECMR, ECDH, A256GCM,
A192GCM, A128GCM, A256CBC-HS512, A192CBC-HS384, A128CBC-HS256, DEF

After appling this patch algorithms listed by `jose_hook_alg_find`
function:
PS512, PS384, PS256, RS512, RS384, RS256, PS512, PS384, PS256,
RS512, RS384, RS256, RSA-OAEP-512, RSA-OAEP-384, RSA-OAEP-256,
RSA-OAEP-224, RSA-OAEP, RSA1_5, PBES2-HS512+A256KW, PBES2-HS384+A192KW,
PBES2-HS256+A128KW, HS512, HS384, HS256, S1, S224, S256, S384, S512,
ES512, ES384, ES256, ECMR, ECDH-ES+A256KW, ECDH-ES+A192KW, ECDH-ES+A128KW,
ECDH-ES, ECDH, dir, A256KW, A192KW, A128KW, A256GCMKW, A192GCMKW, A128GCMKW
'''

Signed-off-by: sunil-dhayal <sunildhayal3001@google.com>