### PR TITLE
do not install COPYING file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -43,15 +43,11 @@ jq = find_program('jq', required: false)
 
 mans = []
 
-licenses = ['COPYING']
-
 subdir('include')
 subdir('doc')
 subdir('lib')
 subdir('cmd')
 subdir('tests')
-
-install_data(licenses, install_dir: licensedir)
 
 pkg = import('pkgconfig')
 pkg.generate(


### PR DESCRIPTION
COPYING file is no essential and better is to leave it in source tree allowing packagers decide what to do with that file.

Remove of that file suggested in #116