### PR TITLE
Build updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,13 @@
 ---
 name: build
 
-on: [push, pull_request]
-
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
 jobs:
   linux:
     runs-on: ubuntu-latest
@@ -39,7 +44,7 @@ jobs:
             os: centos:7
             stable: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Show OS information
         run: |
@@ -87,7 +92,7 @@ jobs:
           - gcc
           - clang
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Show OS information
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+
 jobs:
   linux:
     runs-on: ubuntu-latest
@@ -42,7 +43,7 @@ jobs:
             stable: false
           - compiler: gcc
             os: centos:7
-            stable: true
+            stable: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,9 +41,6 @@ jobs:
           - compiler: clang
             os: ubuntu:devel
             stable: false
-          - compiler: gcc
-            os: centos:7
-            stable: false
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This does two straightforward things.  One, stop doing mass rebuilds when only the documentation has changed, and two update to actions/checkout@v4 in reaction to https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ which will obsolete actions/checkout@v3.  Unfortunately, the update to checkout (and thus node 20) seems to require libraries not available in CentOS 7.  I therefore marked it as unstable in the config to keep its failure from  stopping all other builds.  But I'm really not certain what is the best way to proceed.  It seems like checkout v3 will go end-of-life and not be usable "spring 2024" from the blog entry above.  CentOS 7 is scheduled to go end-of-life at the end of June.  So it seems like something will have to change before CentOS 7 is EOL to keep all the other builds working. The solution here, is probably not ideal, but the choices seem to be remove CentOS 7 altogether or duplicate a bunch of build script to use checkout v3 for CentOS 7. But that would only save it for a few months, still not quite to the end of June.  So marking it unstable is a half-measure to raise the issue until there's a better decision. 