### PR TITLE
Update meson.build

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -2,7 +2,7 @@ flags = '-Wl,--version-script=' + meson.current_source_dir() + '/libjose.map'
 code = 'int main() { return 0; }'
 cc = meson.get_compiler('c')
 
-if not cc.links(code, args: flags, name: '-Wl,--version-script=...')
+if not cc.links(code, args: flags + ',--undefined-version' , name: '-Wl, --version-script=...')
   flags = [ '-export-symbols-regex=^jose_.*' ]
 endif
 

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -2,7 +2,7 @@ flags = '-Wl,--version-script=' + meson.current_source_dir() + '/libjose.map'
 code = 'int main() { return 0; }'
 cc = meson.get_compiler('c')
 
-if not cc.links(code, args: flags + ',--undefined-version' , name: '-Wl, --version-script=...')
+if not cc.links(code, args: flags + ',--undefined-version' , name: '-Wl,--version-script=...')
   flags = [ '-export-symbols-regex=^jose_.*' ]
 endif
 

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -2,8 +2,14 @@ flags = '-Wl,--version-script=' + meson.current_source_dir() + '/libjose.map'
 code = 'int main() { return 0; }'
 cc = meson.get_compiler('c')
 
-if not cc.links(code, args: flags + ',--undefined-version' , name: '-Wl,--version-script=...')
-  flags = [ '-export-symbols-regex=^jose_.*' ]
+if host_machine.system() == 'freebsd'
+  if not cc.links(code, args: flags + ',--undefined-version' , name: '-Wl,--version-script=...')
+     flags = [ '-export-symbols-regex=^jose_.*' ]
+  endif
+else
+  if not cc.links(code, args: flags, name: '-Wl,--version-script=...')
+     flags = [ '-export-symbols-regex=^jose_.*' ]
+  endif
 endif
 
 libjose_lib = shared_library('jose',


### PR DESCRIPTION
Add undefined-version flag to link check for version-script to avoid false failures do to the "code" in the check being trivial. This seems to resolve the problem described in Issue #152 and  https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=277905 without adversely affecting any other builds (including OSX.)