### PR TITLE
Fix potential DoS issue with p2c header

### DIFF
--- a/tests/cve-2023-50967/cve-2023-50967.jwe
+++ b/tests/cve-2023-50967/cve-2023-50967.jwe
@@ -1,0 +1,1 @@
+{"ciphertext":"aaPb-JYGACs-loPwJkZewg","encrypted_key":"P1h8q8wLVxqYsZUuw6iEQTzgXVZHCsu8Eik-oqbE4AJGIDto3gb3SA","header":{"alg":"PBES2-HS256+A128KW","p2c":1000000000,"p2s":"qUQQWWkyyIqculSiC93mlg"},"iv":"Clg3JX9oNl_ck3sLSGrlgg","protected":"eyJlbmMiOiJBMTI4Q0JDLUhTMjU2In0","tag":"i7vga9tJkwRswFd7HlyD_A"}

--- a/tests/cve-2023-50967/cve-2023-50967.jwk
+++ b/tests/cve-2023-50967/cve-2023-50967.jwk
@@ -1,0 +1,1 @@
+{"alg":"PBES2-HS256+A128KW","k":"VHBLJ4-PmnqELoKbQoXuRA","key_ops":["wrapKey","unwrapKey"],"kty":"oct"}

--- a/tests/jose-jwe-dec
+++ b/tests/jose-jwe-dec
@@ -53,3 +53,8 @@ test "`jose jwe dec -i $prfx.12.jweg -k $prfx.12.jwk`"   = "`cat $prfx.12.pt`"
 test "`jose jwe dec -i $prfx.13.jweg -k $prfx.13.1.jwk`" = "`cat $prfx.13.pt`"
 test "`jose jwe dec -i $prfx.13.jweg -k $prfx.13.2.jwk`" = "`cat $prfx.13.pt`"
 test "`jose jwe dec -i $prfx.13.jweg -k $prfx.13.3.jwk`" = "`cat $prfx.13.pt`"
+
+# CVE-2023-50967 - test originally from https://github.com/P3ngu1nW/CVE_Request/blob/main/latch-jose.md
+# This test is expected to fail quickly on patched systems.
+prfx="${CVE_2023_50967}/cve-2023-50967"
+! test "$(jose jwe dec -i $prfx.jwe -k $prfx.jwk)"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -31,6 +31,8 @@ progs = [
 e = environment()
 e.prepend('PATH', meson.current_build_dir() + '/../cmd', separator: ':')
 e.set('VECTORS', meson.current_source_dir() + '/vectors')
+e.set('CVE_2023_50967', meson.current_source_dir() + '/cve-2023-50967')
+
 
 foreach p: progs
   exe = executable(p, p + '.c', dependencies: libjose_dep)


### PR DESCRIPTION
Unbounded p2c headers may be used to cause an application that accept PBES algorithms to spend a lot of resources running PBKDF2 with a very high number of iterations.

Limit the maximum number of iterations to to 32768.

Fixes: CVE-2023-50967