### PR TITLE
Use `-exported_symbol` on macOS

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,15 +1,17 @@
-flags = '-Wl,--version-script=' + meson.current_source_dir() + '/libjose.map'
+flags_name = '-Wl,--version-script='
+flags = flags_name + meson.current_source_dir() + '/libjose.map'
 code = 'int main() { return 0; }'
 cc = meson.get_compiler('c')
 
 if host_machine.system() == 'freebsd'
-  if not cc.links(code, args: flags + ',--undefined-version' , name: '-Wl,--version-script=...')
-     flags = [ '-export-symbols-regex=^jose_.*' ]
-  endif
-else
-  if not cc.links(code, args: flags, name: '-Wl,--version-script=...')
-     flags = [ '-export-symbols-regex=^jose_.*' ]
-  endif
+  flags += ',--undefined-version'
+elif host_machine.system() == 'darwin'
+  flags_name = '-Wl,-exported_symbol,'
+  flags = flags_name + '_jose_*'
+endif
+
+if not cc.links(code, args: flags, name: flags_name + '...')
+  flags = [ '-export-symbols-regex=^jose_.*' ]
 endif
 
 libjose_lib = shared_library('jose',


### PR DESCRIPTION
`--version-script` is not supported on macOS ld while `-export-symbols-regex` seems to be specific to libtool. Previous macOS ld may have skipped this but Xcode 16 fails:
```
clang: error: unknown argument: '-export-symbols-regex=^jose_.*'
```

macOS instead has:
* `-exported_symbol <symbol>`
* `-exported_symbols_list <filename>`

---

Could alternatively use `-exported_symbols_list` and hardcode every name similar to `libjose.map`, but there is a good chance of it going out-of-sync without proper checks as it needs a different file with a flat list of symbols/patterns

May want to consider using visibility attributes instead which should allow better cross-compatibility.

---

The build failure was seen in Homebrew when trying to build `jose` on Sequoia (Xcode 16, based on LLVM 17).

Taking a look at binaries built from older Xcode, the flags were most likely never used, e.g.
```console
❯ nm -gU lib/libjose.dylib | grep -v jose
0000000000010ad6 T _add_entity
000000000001090b T _bn_decode
0000000000010917 T _bn_decode_json
000000000001099a T _bn_encode
0000000000010a26 T _bn_encode_json
0000000000010d3d T _copy_val
0000000000005810 T _encode_protected
0000000000005891 T _handle_zip_enc
0000000000006b84 T _hsh
0000000000006d03 T _hsh_buf
0000000000006ccd T _hsh_io
0000000000010810 T _str2enum
0000000000005886 T _zero
0000000000005997 T _zip_in_protected_header

❯ nm -gU lib/libjose.dylib | grep jose | wc -l
      59
```

Doing a build with `-exported_symbol`
```console
❯ nm -gU lib/libjose.dylib | grep -v jose

❯ nm -gU lib/libjose.dylib | grep jose | wc -l
      59
```