### PR TITLE
cmd/jwk: check return from jose_jwk_thp_buf() properly

### DIFF
--- a/cmd/jwk/thp.c
+++ b/cmd/jwk/thp.c
@@ -153,7 +153,7 @@ jcmd_jwk_thp(int argc, char *argv[])
             if (!opt.find && strcmp(opt.hash, a->name) != 0)
                 continue;
 
-            if (!jose_jwk_thp_buf(NULL, jwk, opt.hash, dec, sizeof(dec))) {
+            if (jose_jwk_thp_buf(NULL, jwk, opt.hash, dec, sizeof(dec)) == SIZE_MAX) {
                 fprintf(stderr, "Error making thumbprint!\n");
                 return EXIT_FAILURE;
             }

--- a/tests/jose-jwk-thp
+++ b/tests/jose-jwk-thp
@@ -20,3 +20,14 @@ thp256="${RFC_7638_3_1}.thp"
 [ "$(jose jwk thp -i ${jwk})" = "$(jose jwk thp -i ${jwk} -a S256)" ]
 [ "$(jose jwk thp -i ${jwk})" = "$(cat ${thp256})" ]
 
+# Github issue #170.
+KEY_ISSUE170='{
+  "use": "sig",
+  "kty": "OKP",
+  "kid": "IpNACexNZWO9hVeADtTT0Nvturu6OtMV3B4u1OVr1fU",
+  "crv": "Ed25519",
+  "alg": "EdDSA",
+  "x": "etkJX1EBhliHzBaimUQb0h2JhJKQ3G0beRVR3ssiedY"
+}'
+# We expect a failure when calculating the thumbprint of KEY_ISSUE170.
+! echo "${KEY_ISSUE170}" | jose jwk thp -i -


### PR DESCRIPTION
`jose_jwk_thp_buf()` returns, on success, the number of bytes written; otherwise, it returns `SIZE_MAX`.

We now check its return properly, from `jcmd_jwk_thp()`, which is used by the CLI utility.

Fixes: #170 