### PR TITLE
openssl: handle NULL in jose_openssl_jwk_from_EC_KEY gracefully

### DIFF
--- a/lib/openssl/jwk.c
+++ b/lib/openssl/jwk.c
@@ -140,6 +140,9 @@ jose_openssl_jwk_from_RSA(jose_cfg_t *cfg, const RSA *key)
 json_t *
 jose_openssl_jwk_from_EC_KEY(jose_cfg_t *cfg, const EC_KEY *key)
 {
+    if (!key)
+        return NULL;
+
     return jose_openssl_jwk_from_EC_POINT(
         cfg,
         EC_KEY_get0_group(key),


### PR DESCRIPTION
We already check that the `RSA *key` is not `NULL` in `jose_openssl_jwk_from_RSA()`, but fail to do so for `EC_KEY *key` in `jose_openssl_jwk_from_EC_KEY()`.

But `EVP_PKEY_get0_EC_KEY()` can return `NULL` too, e.g., if the `EVP_PKEY` comes from an OpenSSL provider that is not creating a keymgmt instance for a public key and the default provider is not loaded[1].

Instead of crashing inside OpenSSL when we pass a NULL pointer to `EC_KEY_get0_private_key()`, detect this case and return gracefully.

[1]: https://github.com/openssl/openssl/discussions/25679