### PR TITLE
Fix FreeBSD linking by simplifying libjose.map

### DIFF
--- a/lib/libjose.map
+++ b/lib/libjose.map
@@ -52,9 +52,6 @@ LIBJOSE_1.0 {
 		jose_jws_sig_io;
 		jose_jws_ver;
 		jose_jws_ver_io;
-
-	local:
-		*;
 };
 
 LIBJOSE_OPENSSL_1.0 {
@@ -66,7 +63,4 @@ LIBJOSE_OPENSSL_1.0 {
 		jose_openssl_jwk_to_EC_KEY;
 		jose_openssl_jwk_to_EVP_PKEY;
 		jose_openssl_jwk_to_RSA;
-
-	local:
-		*;
 };

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -2,7 +2,7 @@ flags = '-Wl,--version-script=' + meson.current_source_dir() + '/libjose.map'
 code = 'int main() { return 0; }'
 cc = meson.get_compiler('c')
 
-if host_machine.system() == 'freebsd'
+if build_machine.system() == 'freebsd'
   if not cc.links(code, args: flags + ',--undefined-version' , name: '-Wl,--version-script=...')
      flags = [ '-export-symbols-regex=^jose_.*' ]
   endif


### PR DESCRIPTION
Remove the locals regexes from libjose.map.  They seem to serve no purpose and are capturing the environ and __prognam symbols from libc on FreeBSD causing various linking errors due to those symbols being erroneously not exported.  Minor change in meson.build to look for build_machine vs. host_machine because the linking is happening on the build machine and thus the linker syntax is build machine dependent.

This should correct #152 
