### PR TITLE
Fix centos:stream based compilation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,8 @@ jobs:
           - clang
         os:
           - fedora:latest
+          - quay.io/centos/centos:stream10
           - quay.io/centos/centos:stream9
-          - quay.io/centos/centos:stream10-development
           - debian:testing
           - debian:latest
           - ubuntu:rolling

--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -41,10 +41,9 @@ centos:7)
 *centos:stream*)
     dnf -y clean all
     dnf -y --allowerasing --setopt=deltarpm=0 update
-    dnf install -y yum-utils epel-release
     dnf config-manager -y --set-enabled crb \
         || dnf config-manager -y --set-enabled powertools || :
-    dnf -y --allowerasing install ${COMMON}
+    dnf install -y --allowerasing yum-utils epel-release ${COMMON}
     dnf builddep -y jose
     ;;
 esac

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 *.swo
 *.trs
 *_t
-.*
 aclocal.m4
 ar-lib
 autom4te.cache


### PR DESCRIPTION
Try fixing centos:stream based compilation by doing installation in the same step:

* The installation of yum-utils, epel-release, and common packages (${COMMON}) on CentOS Stream is now performed in a single dnf command. This helps dnf resolve all dependencies at once, preventing potential inconsistencies that can arise from multi-step installations.

* Updated CentOS Stream image: The CI workflow now uses quay.io/centos/centos:stream10 instead of the unstable stream10-development tag, ensuring a more stable and predictable build environment.